### PR TITLE
Drop TinyDB

### DIFF
--- a/buildbot/Pipfile
+++ b/buildbot/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 flask = "*"
-tinydb = "*"
 gunicorn = "*"
 
 [dev-packages]

--- a/buildbot/buildbot/db.py
+++ b/buildbot/buildbot/db.py
@@ -39,6 +39,11 @@ class JobDB:
 
         self.cv = threading.Condition()
 
+    def job_dir(self, job_name):
+        """Get the path to a job's work directory.
+        """
+        return os.path.join(self.base_path, JOBS_DIR, job_name)
+
     def _info_path(self, name):
         """Get the path to a job's info JSON file."""
         return os.path.join(self.job_dir(name), INFO_FILENAME)
@@ -153,8 +158,3 @@ class JobDB:
         """
         with self.cv:
             return self._read(name)
-
-    def job_dir(self, job_name):
-        """Get the path to a job's work directory.
-        """
-        return os.path.join(self.base_path, JOBS_DIR, job_name)

--- a/buildbot/buildbot/db.py
+++ b/buildbot/buildbot/db.py
@@ -70,7 +70,7 @@ class JobDB:
     def _all(self):
         """Read all the jobs. This is currently quite slow.
         """
-        for name in os.listdir(self.base_path):
+        for name in os.listdir(os.path.join(self.base_path, JOBS_DIR)):
             path = self._info_path(name)
             if os.path.isfile(path):
                 with open(path) as f:

--- a/buildbot/buildbot/db.py
+++ b/buildbot/buildbot/db.py
@@ -1,16 +1,14 @@
-import tinydb
 import threading
 import secrets
 import time
 import os
 from contextlib import contextmanager
+import json
 
-DB_FILENAME = 'db.json'
 JOBS_DIR = 'jobs'
 ARCHIVE_NAME = 'code'
 CODE_DIR = 'code'
-
-Job = tinydb.Query()
+INFO_FILENAME = 'info.json'
 
 
 @contextmanager
@@ -39,26 +37,44 @@ class JobDB:
         os.makedirs(self.base_path, exist_ok=True)
         os.makedirs(os.path.join(self.base_path, JOBS_DIR), exist_ok=True)
 
-        self.db = tinydb.TinyDB(os.path.join(base_path, DB_FILENAME))
-        self.jobs = self.db.table('jobs')
-
         self.cv = threading.Condition()
 
     def _count(self, state):
         """Get the number of jobs in the database in a given state.
         """
-        return len(self.jobs.search(tinydb.Query().state == state))
+        return len([job for job in self._all()
+                    if job['state'] == state])
 
-    def _get(self, name):
-        """Get a job by its name.
+    def _info_path(self, name):
+        """Get the path to a job's info JSON file."""
+        return os.path.join(self.job_dir(name), INFO_FILENAME)
+
+    def _read(self, name):
+        """Read a job from its info file.
 
         Raise a NotFoundError if there is no such job.
         """
-        matches = self.jobs.search(tinydb.Query().name == name)
-        if not matches:
+        path = self._info_path(name)
+        if os.path.isfile(path):
+            with open(path) as f:
+                return json.load(f)
+        else:
             raise NotFoundError()
-        assert len(matches) == 1
-        return matches[0]
+
+    def _write(self, job):
+        """Write a job back to its info file.
+        """
+        with open(self._info_path(job['name']), 'w') as f:
+            json.dump(job, f)
+
+    def _all(self):
+        """Read all the jobs. This is currently quite slow.
+        """
+        for name in os.listdir(self.base_path):
+            path = self._info_path(name)
+            if os.path.isfile(path):
+                with open(path) as f:
+                    yield json.load(f)
 
     def _acquire(self, old_state, new_state):
         """Look for a job in `old_state`, update it to `new_state`, and
@@ -66,26 +82,30 @@ class JobDB:
 
         Raise a `NotFoundError` if there is no such job.
         """
-        matches = self.jobs.search(tinydb.Query().state == old_state)
-        if not matches:
+        for job in self._all():
+            if job['state'] == old_state:
+                break
+        else:
             raise NotFoundError()
-        job = matches[0]
 
         job['state'] = new_state
         log(job, 'acquired in state {}'.format(new_state))
-        self.jobs.write_back([job])
+        with open(self._info_path(job['name']), 'w') as f:
+            json.dump(job, f)
 
         return job
 
     def _add(self, state):
         name = secrets.token_urlsafe(8)
-        doc_id = self.jobs.insert({
+        job = {
             'name': name,
             'started': time.time(),
             'state': state,
             'log': [],
-        })
-        return self.jobs.get(doc_id=doc_id)
+        }
+        os.mkdir(self.job_dir(name))
+        self._write(job)
+        return job
 
     def add(self, state):
         """Add a new job and return it.
@@ -103,7 +123,6 @@ class JobDB:
         """
         job = self.add(start_state)
         path = self.job_dir(job['name'])
-        os.mkdir(path)
         with chdir(path):
             yield job
         self.set_state(job, end_state)
@@ -114,7 +133,7 @@ class JobDB:
         with self.cv:
             job['state'] = state
             log(job, 'state changed to {}'.format(state))
-            self.jobs.write_back([job])
+            self._write(job)
             self.cv.notify_all()
 
     def acquire(self, old_state, new_state):
@@ -131,7 +150,7 @@ class JobDB:
         """Get the job with the given name.
         """
         with self.cv:
-            return self._get(name)
+            return self._read(name)
 
     def job_dir(self, job_name):
         """Get the path to a job's work directory.

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -114,7 +114,7 @@ def jobs_csv():
     )
     writer.writeheader()
 
-    for job in db.jobs:
+    for job in db._all():
         writer.writerow({
             'name': job['name'],
             'started': job['started'],
@@ -127,7 +127,7 @@ def jobs_csv():
 
 @app.route('/')
 def jobs_html():
-    return flask.render_template('joblist.html', jobs=db.jobs)
+    return flask.render_template('joblist.html', jobs=db._all())
 
 
 @app.route('/live.html')


### PR DESCRIPTION
These changes remove the buildbot's dependency on [TinyDB](https://github.com/msiemens/tinydb), which was nice for getting started but maybe not so necessary anymore. Instead, the idea is to write a small `info.json` file *for every job* as an alternative to having one big database, which should be a bit simpler and more robust. To delete a job now, for example, you just have to delete its directory from the disk (no need to fiddle around with the database at all).

I'm mostly sure this works, but I'm not merging it quite yet so we can test it a little more.