### PR TITLE
Multiple dimension array access bug fix

### DIFF
--- a/docs/indextype.md
+++ b/docs/indextype.md
@@ -93,15 +93,35 @@ Consider the value space of $i$, which is:
 
 $$
 \begin{aligned}
-&\phantom{=}
-\{ s + |l_s..h_s| \times d ~|~ s \in l_s..h_s, d \in l_d..h_d\}
-\\
-&=
-\left\{ s + k \times d ~|~ s \in 0..k, d \in \frac{l}{k}..\frac{h}{k}\right\}
+S_u &= \{ s + |l_s..h_s| \times d \mid s \in l_s..h_s, d \in l_d..h_d\} \\
+    &= \left\{ s + k \times d \mid s \in 0..k, d \in \frac{l}{k}..\frac{h}{k}\right\}
 \end{aligned}
 $$
 
-which should be equal to $l..h$, but I don't yet have an algebraic argument for why.
+which is equal to $l..h$.
+
+**Proof.** For unrolling, we want to show that $S_u = l..h$. This ensures that
+an unrolled loop accesses exactly the elements that the original loop did. The
+proof shows that there are exactly $n = |l..h|$ distinct natural numbers in $S_u$
+with $0$ and $n-1$ being the lower and upper bounds.
+
+$$
+\begin{aligned}
+S_u &= \left\{ s + k \times d \mid s \in 0..k, d \in \frac{l}{k}..\frac{h}{k}\right\} \\
+    &= \bigcup_{d \in \frac{l}{k}..\frac{h}{k}}\{ s + k \times d \mid s \in 0..k \}
+\end{aligned}
+$$
+
+Let each of the smaller subsets be $S_i$ where $i$ is equal to the value of $d$.
+Therefore, we have $S_u = \cup S_i$. Next, we show that each $S_i$ has exactly
+$k$ elements and that $\max(S_i) \leq min(S_{i+1})$.
+
+$$
+\begin{aligned}
+\max(S_i) = k - 1 +
+\end{aligned}
+$$
+
 
 Operations
 ----------

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -64,3 +64,9 @@ let improper_unroll =
 let range_static_error =
   "[Type Error] range start/end must be static"
 
+let incorrect_aa_dims aname expected actual =
+  let e_dim_end = if expected = 1 then "" else "s" in
+  let a_dim_end = if actual   = 1 then "" else "s" in
+  "[Type Error] array \"" ^ aname ^ "\" has " ^ (string_of_int expected) ^
+  " dimension" ^ e_dim_end ^ "; attempted array access implies " ^ 
+  (string_of_int actual) ^ " dimension" ^ a_dim_end


### PR DESCRIPTION
Error message "`Index must contain static information`" was appearing in examples `multaccess.sea` and `matadd.sea`, when it didn't make sense. Now:
  - `multaccess.sea` is not rejected and correctly compiles to C (even thought it suffers the read-write problem, but this is not handled yet)
  - `matadd.sea` is (hopefully correctly) rejected with a new error message: `[Type Error] array "c" has 1 dimension; attempted array access implies 2 dimensions`

Will resolve #4.