### PR TITLE
Enable unused variables warning

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -26,7 +26,7 @@ let empty_gamma = {
 
 let empty_delta = StringMap.empty
 
-let rec create_set s =
+let create_set s =
   let rec create_set' i acc =
     if i=0 then (IntSet.add 0 acc)
     else create_set' (i-1) (IntSet.add i acc)
@@ -45,7 +45,7 @@ let add_binding id t g =
       type_map = type_map' ;
       indices_available = indices_available'
     }
-  | t -> { g with type_map = type_map' }
+  | _ -> { g with type_map = type_map' }
 
 let add_alias_binding id t d =
   StringMap.add id t d
@@ -70,7 +70,7 @@ let consume_aa id i g =
   }
   else raise (AlreadyConsumed i)
 
-let rec consume_aa_lst id lst g =
+let consume_aa_lst id lst g =
   let consume_indices = fun context bank ->
     try consume_aa id bank context
     with AlreadyConsumed i -> raise (AlreadyConsumed i)

--- a/src/dune
+++ b/src/dune
@@ -6,3 +6,7 @@
 (library
   (name seashell)
   (libraries core))
+
+(env
+  (default
+    (flags (:standard -short-paths -w A-4))))

--- a/src/dune
+++ b/src/dune
@@ -9,4 +9,4 @@
 
 (env
   (default
-    (flags (:standard -short-paths -w A-4))))
+    (flags (:standard -short-paths -w +a-4 -warn-error +a-4 ))))

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -141,17 +141,12 @@ let rec emit_cmd i cmd =
   | CFuncDef (id, args, body)      -> emit_fun (id, args, body) i
   | CApp (id, args)                -> emit_app (id, args) i
   | CTypeDef (id, t)               -> emit_typedef (id, t) i
-  | CMuxDef _        -> emit_muxdef
+  | CMuxDef _                      -> ""
 
 and emit_assign_int (id, e) =
   concat [ "int "; id; " = "; (emit_expr e); ";" ]
 
-<<<<<<< HEAD
 and emit_assign_arr (id, _, d) i =
-=======
-(* FIXME(rachit): [e] is unused. Remove it from param list or use it. *)
-and emit_assign_arr (id, e, d) i =
->>>>>>> c1b794ad77d439e39b941fb48e3fd637ca37f61d
   let bf = compute_bf d in
   let arr_size = compute_array_size d in
   let part_pragma =
@@ -219,12 +214,6 @@ and emit_fun (id, args, body) i =
 and emit_typedef (id, t) i =
   concat [ "typedef "; (type_str t); " "; id; ";" ]
   |> indent i
-
-<<<<<<< HEAD
-and emit_muxdef _ = "" (* No need to emit anything *)
-=======
-and emit_muxdef = "" (* No need to emit anything *)
->>>>>>> c1b794ad77d439e39b941fb48e3fd637ca37f61d
 
 and generate_c cmd =
   emit_cmd 0 cmd

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -43,6 +43,7 @@ let rec type_str = function
   | TIndex _      -> "int"
   | TArray _ -> failwith "Implement array type stringified version"
   | TAlias id -> type_str (!delta_map id)
+  | _ -> failwith "Implement me!"
 
 let bop_str = function
   | BopEq -> "="
@@ -166,6 +167,7 @@ and emit_assign (id, e) i =
   | TBool         -> emit_assign_int (id, e)         |> indent i
   | TArray (_, d) -> emit_assign_arr (id, e, d) i    |> indent i
   | TFloat        -> emit_assign_float (id, e)       |> indent i
+  | _ -> failwith "Fail me!"
 
 and emit_reassign (target, e) i =
   concat [ (emit_expr target); " = "; (emit_expr e); ";" ] |> indent i

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -41,8 +41,8 @@ let rec type_str = function
   | TBool
   | TFloat        -> "float"
   | TIndex _      -> "int"
-  | TArray (t, _) -> failwith "Implement array type stringified version"
-  | TAlias id -> type_str (!delta_map id)
+  | TArray (_, _) -> failwith "Implement array type stringified version"
+  | TAlias id     -> type_str (!delta_map id)
 
 let bop_str = function
   | BopEq -> "="
@@ -146,7 +146,7 @@ let rec emit_cmd i cmd =
 and emit_assign_int (id, e) =
   concat [ "int "; id; " = "; (emit_expr e); ";" ]
 
-and emit_assign_arr (id, e, d) i =
+and emit_assign_arr (id, _, d) i =
   let bf = compute_bf d in
   let arr_size = compute_array_size d in
   let part_pragma =
@@ -164,7 +164,7 @@ and emit_assign (id, e) i =
   match !type_map id with
   | TIndex _      -> emit_assign_int (id, e)         |> indent i
   | TBool         -> emit_assign_int (id, e)         |> indent i
-  | TArray (t, d) -> emit_assign_arr (id, e, d) i    |> indent i
+  | TArray (_, d) -> emit_assign_arr (id, e, d) i    |> indent i
   | TFloat        -> emit_assign_float (id, e)       |> indent i
 
 and emit_reassign (target, e) i =
@@ -215,7 +215,7 @@ and emit_typedef (id, t) i =
   concat [ "typedef "; (type_str t); " "; id; ";" ]
   |> indent i
 
-and emit_muxdef (m_id, a_id, s) = "" (* No need to emit anything *)
+and emit_muxdef _ = "" (* No need to emit anything *)
 
 and generate_c cmd =
   emit_cmd 0 cmd

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -10,6 +10,7 @@ let rec string_of_type = function
   | TAlias id -> id
   | TFloat -> "float"
   | TFunc _ -> "func"
+  | _ -> failwith "Implement me!"
 
 let string_of_binop = function
   | BopEq    -> "="

--- a/src/op_util.ml
+++ b/src/op_util.ml
@@ -1,5 +1,4 @@
 open Ast
-open Context
 
 exception IllegalOperation
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -142,7 +142,6 @@ and check_for_impl id r1 r2 body u (ctx, delta) =
     else raise (TypeError range_static_error)
   | _ -> raise (TypeError range_error)
 
-(* TODO(rachit): [d] is unused. Is this a mistake? *)
 and check_assignment id exp (ctx, delta) =
   check_expr exp (ctx, delta) |> fun (t, (c, d)) ->
   Context.add_binding id t c, d

--- a/src/type.ml
+++ b/src/type.ml
@@ -124,8 +124,8 @@ and check_for id r1 r2 body (ctx, d) =
   | _ -> raise (TypeError range_error)
 
 and check_for_impl id r1 r2 body u (ctx, delta) =
-  check_expr r1 (ctx, delta) |> fun (r1_type, (_, _)) ->
-  check_expr r2 (ctx, delta) |> fun (r2_type, (c2, d2)) ->
+  check_expr r1 (ctx, delta) |> fun (r1_type, (ctx1, d1)) ->
+  check_expr r2 (ctx1, d1)   |> fun (r2_type, (ctx2, d2)) ->
   match r1_type, r2_type with
   | TIndex (st1, _), TIndex (st2, _) ->
     let (ls_1, hs_1) = st1 in
@@ -135,17 +135,17 @@ and check_for_impl id r1 r2 body u (ctx, delta) =
       (* FIXME: redundant *)
       if (range_size=u) then
         let typ = TIndex ((0, u), (0, 1))
-        in check_cmd body (Context.add_binding id typ c2, d2)
+        in check_cmd body (Context.add_binding id typ ctx2, d2)
       else
         let typ = TIndex ((0, u), (0, (range_size/u)))
-        in check_cmd body ((Context.add_binding id typ c2), d2))
+        in check_cmd body ((Context.add_binding id typ ctx2), d2))
     else raise (TypeError range_static_error)
   | _ -> raise (TypeError range_error)
 
 (* TODO(rachit): [d] is unused. Is this a mistake? *)
 and check_assignment id exp (ctx, delta) =
-  check_expr exp (ctx, delta) |> fun (t, (c, _)) ->
-  Context.add_binding id t c, delta
+  check_expr exp (ctx, delta) |> fun (t, (c, d)) ->
+  Context.add_binding id t c, d
 
 (* TODO(ted): rethink this *)
 and check_reassign target exp (ctx, delta) =

--- a/src/type.ml
+++ b/src/type.ml
@@ -124,10 +124,10 @@ and check_for id r1 r2 body (ctx, d) =
   | _ -> raise (TypeError range_error)
 
 and check_for_impl id r1 r2 body u (ctx, delta) =
-  check_expr r1 (ctx, delta) |> fun (r1_type, (c1, d1)) ->
+  check_expr r1 (ctx, delta) |> fun (r1_type, (_, _)) ->
   check_expr r2 (ctx, delta) |> fun (r2_type, (c2, d2)) ->
   match r1_type, r2_type with
-  | TIndex (st1, dyn1), TIndex (st2, dyn2) ->
+  | TIndex (st1, _), TIndex (st2, _) ->
     let (ls_1, hs_1) = st1 in
     let (ls_2, hs_2) = st2 in
     if (hs_1 - ls_1 = 1) && (hs_2 - ls_2 = 1) then (
@@ -144,7 +144,7 @@ and check_for_impl id r1 r2 body u (ctx, delta) =
 
 (* TODO(rachit): [d] is unused. Is this a mistake? *)
 and check_assignment id exp (ctx, delta) =
-  check_expr exp (ctx, delta) |> fun (t, (c, d)) ->
+  check_expr exp (ctx, delta) |> fun (t, (c, _)) ->
   Context.add_binding id t c, delta
 
 (* TODO(ted): rethink this *)


### PR DESCRIPTION
@tedbauer I'm enabling stricter checks for the project. The build system throws a few unused variable warnings now. Can you build this branch and change any intentional unused variables to `_`?