### PR TITLE
Handle TAlias before type checking

### DIFF
--- a/bin/seac.ml
+++ b/bin/seac.ml
@@ -3,17 +3,17 @@ open Cmdliner
 open Seashell
 open Compile_utils
 
-let seac filename no_typecheck =
-  Printexc.record_backtrace false;
+let seac filename no_typecheck : unit =
   let prog = In_channel.read_all filename in
   let ast = parse_with_error prog in
-  let (ctx, dta) = begin
+  let rast = Resolve_alias.remove_aliases ast in
+  let ctx = begin
     if not no_typecheck then
-      typecheck_with_error ast
+      typecheck_with_error rast
     else
-      Context.empty_gamma, Context.empty_delta
+      Context.empty_gamma
   end in
-  emit_code ast ctx dta
+  emit_code rast ctx
 
 let filename =
   let doc = "The file to be compiler by the seashell compiler." in

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -103,6 +103,7 @@ type expr =
  *   - [CSeq (c1, c2)]: a representation of the command [c1]
  *     followed by [c2]
  *   - [CFuncDef, CTypeDef, CMuxDef, CApp]: TODO *)
+(** TODO(rachit): Add CEmpty *)
 type command =
   | CWrite of expr * id
   | CAssign of id * expr

--- a/src/compile_utils.ml
+++ b/src/compile_utils.ml
@@ -16,12 +16,11 @@ let parse_with_error prog =
 
 let typecheck_with_error (ast : Ast.command) =
   try
-    Type.check_cmd ast (Context.empty_gamma, Context.empty_delta)
+    Type.typecheck ast
   with
     Type.TypeError s -> failwith s
 
 
-let emit_code ast ctx dta =
+let emit_code ast ctx =
   Emit.set_type_map (fun id -> Context.get_binding id ctx);
-  Emit.set_delta_map (fun id -> Context.get_alias_binding id dta);
   print_endline (Emit.generate_c ast)

--- a/src/context.ml
+++ b/src/context.ml
@@ -17,14 +17,10 @@ type gamma = {
   indices_available: IntSet.t StringMap.t
 }
 
-type delta = type_node StringMap.t
-
 let empty_gamma = {
   type_map = StringMap.empty ;
   indices_available = StringMap.empty
 }
-
-let empty_delta = StringMap.empty
 
 let create_set s =
   let rec create_set' i acc =
@@ -47,15 +43,8 @@ let add_binding id t g =
     }
   | _ -> { g with type_map = type_map' }
 
-let add_alias_binding id t d =
-  StringMap.add id t d
-
 let get_binding id g =
   try StringMap.find id g.type_map
-  with Not_found -> raise (NoBinding id)
-
-let get_alias_binding id d =
-  try StringMap.find id d
   with Not_found -> raise (NoBinding id)
 
 let consume_aa id i g =

--- a/src/context.mli
+++ b/src/context.mli
@@ -10,25 +10,14 @@ exception NoBinding of id
 (* [gamma] is a type for a typing context that binds IDs to types. *)
 type gamma
 
-(* [delta] is a type for a mapping between alias IDs and types. *)
-type delta
-
 val empty_gamma : gamma
-val empty_delta : delta
 
 (* [add_binding id t g] is a new gamma [g'] with type_node [t] bound to [id]. *)
 val add_binding : id -> type_node -> gamma -> gamma
 
-(* [add_alias_binding id t d] is a new delta [d'] with type_node [t] bound to [id]. *)
-val add_alias_binding : id -> type_node -> delta -> delta
-
 (* [get_binding id g] is [t] that's bound to [id] in gamma [g],
    if such a binding exists; else, raises [NoBinding]. *)
 val get_binding : id -> gamma -> type_node
-
-(* [get_alias_binding id d] is [t] that's bound to [id] in delta [d],
-   if such a binding exists; else, raises [NoBinding]. *)
-val get_alias_binding : id -> delta -> type_node
 
 (* [consume_aa id n g] is [g'] where [g'] is a gamma with the
    index [n] of array with id [id] is consumed. Raises [AlreadyConsumed] if

--- a/src/emit.mli
+++ b/src/emit.mli
@@ -4,6 +4,4 @@ val type_map : (id -> type_node) ref
 
 val set_type_map : (id -> type_node) -> unit
 
-val set_delta_map : (id -> type_node) -> unit
-
 val generate_c : command -> string

--- a/src/op_util.ml
+++ b/src/op_util.ml
@@ -35,12 +35,4 @@ let op_map a b op =
   | TIndex (s1, d1), TIndex (s2, d2), _ -> resolve_index_op (s1, d1) (s2, d2)
   | _                                   -> raise IllegalOperation
 
-let rec determine_type t d =
-  match t with
-  | TAlias id -> determine_type (Context.get_alias_binding id d) d
-  | t -> t
-
-let type_of_op a b d op =
-  let a_type = determine_type a d in
-  let b_type = determine_type b d in
-  op_map a_type b_type op
+let type_of_op a b op = op_map a b op

--- a/src/op_util.mli
+++ b/src/op_util.mli
@@ -1,6 +1,5 @@
 open Ast
-open Context
 
 exception IllegalOperation
 
-val type_of_op : type_node -> type_node -> delta -> binop -> type_node
+val type_of_op : type_node -> type_node -> binop -> type_node

--- a/src/resolve_alias.ml
+++ b/src/resolve_alias.ml
@@ -1,5 +1,16 @@
 open Ast
-open Context
+
+module StringMap =
+  Map.Make(struct type t = id;; let compare = String.compare end)
+
+type delta = type_node StringMap.t
+
+let add_alias_binding id t d =
+  StringMap.add id t d
+
+let get_alias_binding id d =
+  try StringMap.find id d
+  with Not_found -> raise (Context.NoBinding id)
 
 let rec resolve_type typ dta = match typ with
   | TBool | TFloat | TMux _ | TIndex _ -> typ
@@ -30,3 +41,5 @@ and resolve_cmd cmd dta : command * delta = match cmd with
       let (c1, dta1) = resolve_cmd c dta in
       CFuncDef(id, id_typ_lst1, c1), dta1
   | CTypeDef (id, typ) -> cmd, add_alias_binding id (resolve_type typ dta) dta
+
+let remove_aliases cmd = fst @@ resolve_cmd cmd StringMap.empty

--- a/src/resolve_alias.ml
+++ b/src/resolve_alias.ml
@@ -1,0 +1,32 @@
+open Ast
+open Context
+
+let rec resolve_type typ dta = match typ with
+  | TBool | TFloat | TMux _ | TIndex _ -> typ
+  | TAlias id -> get_alias_binding id dta
+  | TArray (t, ts) -> TArray (resolve_type t dta, ts)
+  | TFunc tlist -> TFunc (List.map (fun t -> resolve_type t dta) tlist)
+
+let rec resolve_cmd_seq clst dta = match clst with
+  | [] -> ([], dta)
+  | cmd :: tl ->
+      let (c1, dta1) = resolve_cmd cmd dta in
+      let (ctl, dta2) = resolve_cmd_seq tl dta1 in
+      c1 :: ctl, dta2
+
+and resolve_cmd cmd dta : command * delta = match cmd with
+  | CMuxDef _ | CWrite _ | CAssign _ | CReassign _ | CApp _ | CExpr _ -> cmd, dta
+  | CIf (e, c) ->
+      let (c1, dta1) = resolve_cmd c dta in
+      CIf (e, c1), dta1
+  | CFor (id, e1, e2, un, c) ->
+      let (c1, dta1) = resolve_cmd c dta in
+      CFor (id, e1, e2, un, c1), dta1
+  | CSeq clst ->
+      let (clst1, dta1) = resolve_cmd_seq clst dta in
+      CSeq clst1, dta1
+  | CFuncDef (id, id_typ_lst, c) ->
+      let id_typ_lst1 = List.map (fun (i, t) -> i, resolve_type t dta) id_typ_lst in
+      let (c1, dta1) = resolve_cmd c dta in
+      CFuncDef(id, id_typ_lst1, c1), dta1
+  | CTypeDef (id, typ) -> cmd, add_alias_binding id (resolve_type typ dta) dta

--- a/src/resolve_alias.mli
+++ b/src/resolve_alias.mli
@@ -1,0 +1,1 @@
+val remove_aliases : Ast.command -> Ast.command

--- a/src/type.ml
+++ b/src/type.ml
@@ -4,45 +4,47 @@ open Error_msg
 
 exception TypeError of string
 
-(** [compute_bf d] is a banking factor [b], computed from [d], where
- * [d] specifies the banking structure of some [TArray (t, d)].
+(** [compute_bf dims] is a banking factor [b], computed from [dims], where
+ * [d] specifies the banking structure of some [TArray (t, dims)].
  * This relies on the assumption that our ideas about banking across
  * multiple dimensions is correct; these ideas are detailed in
  * [https://capra.cs.cornell.edu/seashell/docs/indextype.html]. *)
-let compute_bf lst =
-  List.fold_left (fun acc (_, b) -> acc * b) 1 lst
+let compute_bf dims =
+  List.fold_left (fun acc (_, b) -> acc * b) 1 dims
 
 (** Computes equality between [t1] and [t2] and handles type aliases.
  *  Also special cases [TIndex] so that any two [TIndex] are equal. *)
-let rec types_equal (delta : delta) (t1 : type_node) (t2 : type_node) : bool =
+let rec types_equal (t1 : type_node) (t2 : type_node) : bool =
   match t1, t2 with
-  | TArray (a1, d1), TArray (a2, d2) -> d1=d2 && types_equal delta a1 a2
+  | TArray (a1, d1), TArray (a2, d2) -> d1=d2 && types_equal a1 a2
   | TIndex _, TIndex _ -> true
-  | TAlias ta, t | t, TAlias ta ->
-      types_equal delta t (Context.get_alias_binding ta delta)
+  | TAlias _, _ | _, TAlias _ ->
+      (*types_equal delta t (Context.get_alias_binding ta delta)*)
+      (**TODO(rachit): Add malformed AST exception *)
+      failwith "TAlias should not be present in AST after resolution pass."
   | t1, t2 -> t1=t2
 
 (** [check_expr exp (ctx, delta)] is [t, (ctx', delta')], where [t] is the
  * type of [exp] under context (ctx, delta) and (ctx', delta') is an updated
  * context resulting from type-checking [exp]. Raises [TypeError s] if there
  * is a type error in [exp].*)
-let rec check_expr exp (ctx, delta) =
+let rec check_expr exp ctx : type_node * gamma =
   match exp with
-  | EFloat _                   -> TFloat, (ctx, delta)
-  | EBool _                    -> TBool, (ctx, delta)
-  | EInt i                     -> TIndex ((i, i+1), (0, 1)), (ctx, delta)
-  | EVar x                     -> Context.get_binding x ctx, (ctx, delta)
-  | EBinop (binop, e1, e2)     -> check_binop binop e1 e2 (ctx, delta)
-  | EBankedAA (id, idx1, idx2) -> check_banked_aa id idx1 idx2 (ctx, delta)
-  | EAA (id, i)                -> check_aa id i (ctx, delta)
+  | EFloat _                   -> TFloat, ctx
+  | EBool _                    -> TBool, ctx
+  | EInt i                     -> TIndex ((i, i+1), (0, 1)), ctx
+  | EVar x                     -> Context.get_binding x ctx, ctx
+  | EBinop (binop, e1, e2)     -> check_binop binop e1 e2 ctx
+  | EBankedAA (id, idx1, idx2) -> check_banked_aa id idx1 idx2 ctx
+  | EAA (id, i)                -> check_aa id i ctx
 
 (** [check_binop b e1 e2 (c, d)] is [(t, (c', d')], where [t] is the type of
  * the expression [EBinop (b, e1, e2)] and [(c', d')] is the updated context
  * resulting from the type-checking of [e1] and [e2]. *)
-and check_binop binop e1 e2 (c, d) =
-  let (t1, (c1, d1)) = check_expr e1 (c, d) in
-  let (t2, (c2, d2)) = check_expr e2 (c1, d1) in
-  try (Op_util.type_of_op t1 t2 d binop), (c2, d2)
+and check_binop binop e1 e2 c : type_node * gamma =
+  let (t1, c1) = check_expr e1 c in
+  let (t2, c2) = check_expr e2 c1 in
+  try (Op_util.type_of_op t1 t2 binop), c2
   with Op_util.IllegalOperation -> raise @@ TypeError (illegal_op binop t1 t2)
 
 (* [check_banked_aa id idx1 idx2 (c, d)] represents a _banked
@@ -53,15 +55,15 @@ and check_binop binop e1 e2 (c, d) =
  * indices of array [id]. Raises [TypeError s] if:
  *   - [idx1] or [idx2] are illegal types (non-index types)
  *   - illegal banks are accessed (i.e. already-consumed indices) *)
-and check_banked_aa id idx1 idx2 (c, d) =
-  let idx1_t, (c1, d1) = check_expr idx1 (c, d) in
-  let idx2_t, (c2, d2) = check_expr idx2 (c1, d1) in
+and check_banked_aa id idx1 idx2 c : type_node * gamma =
+  let idx1_t, c1 = check_expr idx1 c in
+  let idx2_t, c2 = check_expr idx2 c1 in
   match idx1_t, idx2_t, Context.get_binding id c2 with
   | TIndex (s1, d1), TIndex (_, _), TArray (a_t, _) ->
     let (ls_1, hs_1) = s1 and (ld_1, hd_1) = d1 in
     if hs_1 - ls_1 = 1 && hd_1 - ld_1 = 1 then
       begin
-        try a_t, (Context.consume_aa id ls_1 c2, d2)
+        try a_t, Context.consume_aa id ls_1 c2
         with AlreadyConsumed i -> raise @@ TypeError (illegal_bank i id)
       end
     else
@@ -72,12 +74,12 @@ and check_banked_aa id idx1 idx2 (c, d) =
  * the index type accessor expressions [idx_exprs], each of which should be of
  * type [TIndex (s, d)]. Raises [TypeError s] if [idx_exprs] contains invalid
  * array access types, i.e. non-index types. *)
-and compute_unrollf idx_exprs (c, d) =
+and compute_unrollf idx_exprs c =
   match idx_exprs with
   | h::t ->
     begin
-      match check_expr h (c, d) with
-      | TIndex ((ls, hs), _), _ -> (hs - ls) * compute_unrollf t (c, d)
+      match check_expr h c with
+      | TIndex ((ls, hs), _), _ -> (hs - ls) * compute_unrollf t c
       | _ -> raise (TypeError "Logical array access must be with idx types")
     end
   | [] -> 1
@@ -90,7 +92,7 @@ and compute_unrollf idx_exprs (c, d) =
  * and consuming the appropriate array indices. Raises [TypeError s] if:
  *  - an expression in [idx_exprs] is an illegal type (i.e. not TIndex _)
     - illegal banks are accessed (i.e. already consumed banks) *)
-and check_aa id idx_exprs (c, d) =
+and check_aa id idx_exprs c : type_node * gamma =
   match Context.get_binding id c with
   | TArray (t, dims) ->
     let num_dimensions = List.length dims in
@@ -100,11 +102,11 @@ and check_aa id idx_exprs (c, d) =
         (TypeError (incorrect_aa_dims id num_dimensions access_dimensions))
     else
       let bf = compute_bf dims in
-      let unrollf = compute_unrollf idx_exprs (c, d) in
+      let unrollf = compute_unrollf idx_exprs c in
       if (bf mod unrollf)=0 then
         try
           let banks = Core.List.range 0 (unrollf-1) in
-          t, (Context.consume_aa_lst id banks c, d)
+          t, (Context.consume_aa_lst id banks c)
         with AlreadyConsumed bank -> raise @@ TypeError (illegal_bank bank id)
       else
         raise (TypeError "TypeError: unroll factor must be factor of banking factor")
@@ -112,29 +114,29 @@ and check_aa id idx_exprs (c, d) =
 
 (** [check_cmd cmd (c, d)] is [(c', d')], an updated context resutling from
  * type-checking command [cmd], Raises [TypeError s]. *)
-let rec check_cmd cmd (ctx, delta) =
+let rec check_cmd cmd ctx : gamma =
   match cmd with
-  | CSeq clist                     -> check_seq clist (ctx, delta)
-  | CIf (cond, cmd)                -> check_if cond cmd (ctx, delta)
-  | CFor (x, r1, r2, uo, body)     -> check_for x r1 r2 body uo (ctx, delta)
-  | CAssign (x, e1)                -> check_assignment x e1 (ctx, delta)
-  | CReassign (target, exp)        -> check_reassign target exp (ctx, delta)
-  | CFuncDef (id, args, body)      -> check_funcdef id args body (ctx, delta)
-  | CApp (id, args)                -> check_app id args (ctx, delta)
-  | CTypeDef (id, t)               -> check_typedef id t (ctx, delta)
-  | CMuxDef (mux_id, mem_id, size) -> check_muxdef mux_id mem_id size (ctx, delta)
-  | CExpr expr                     -> snd @@ check_expr expr (ctx, delta)
+  | CSeq clist                     -> check_seq clist ctx
+  | CIf (cond, cmd)                -> check_if cond cmd ctx
+  | CFor (x, r1, r2, uo, body)     -> check_for x r1 r2 body uo ctx
+  | CAssign (x, e1)                -> check_assignment x e1 ctx
+  | CReassign (target, exp)        -> check_reassign target exp ctx
+  | CFuncDef (id, args, body)      -> check_funcdef id args body ctx
+  | CApp (id, args)                -> check_app id args ctx
+  | CTypeDef _                     -> ctx
+  | CMuxDef (mux_id, mem_id, size) -> check_muxdef mux_id mem_id size ctx
+  | CExpr expr                     -> snd @@ check_expr expr ctx
   | CWrite _                       -> failwith "capabilities not implemented"
 
-and check_seq clist (ctx, delta) =
-  let f (c, d) cmd = check_cmd cmd (c, d) in
-  List.fold_left f (ctx, delta) clist
+and check_seq clist ctx =
+  let f c cmd = check_cmd cmd c in
+  List.fold_left f ctx clist
 
 (** [check_if cond cmd (c, d)] is [(c', d')], an updated context resulting from
  * type-checking [cond], followed by [cmd]. *)
-and check_if cond cmd (ctx, delta) =
-  match check_expr cond (ctx, delta) with
-  | TBool, (ctx', dta') -> check_cmd cmd (ctx', dta')
+and check_if cond cmd ctx =
+  match check_expr cond ctx with
+  | TBool, ctx' -> check_cmd cmd ctx'
   | t, _ -> raise (TypeError (unexpected_type "conditional" t TBool))
 
 (** [check_for id r1 r2 body u (c, d)] is [(c', d')], an updated context resulting
@@ -144,9 +146,9 @@ and check_if cond cmd (ctx, delta) =
  *   - [body], the body of the for loop
  * Additionally, unroll factor [u] influences the type bound to [id] (see Seashell
  * notes) *)
-and check_for id r1 r2 body u (ctx, delta) =
-  let r1_type, (ctx1, d1) = check_expr r1 (ctx, delta) in
-  let r2_type, (ctx2, d2) = check_expr r2 (ctx1, d1) in
+and check_for id r1 r2 body u ctx =
+  let r1_type, ctx1 = check_expr r1 ctx in
+  let r2_type, ctx2 = check_expr r2 ctx1 in
   match r1_type, r2_type with
   | TIndex (st1, _), TIndex (st2, _) ->
     let (ls_1, hs_1) = st1 in
@@ -154,31 +156,31 @@ and check_for id r1 r2 body u (ctx, delta) =
     if (hs_1 - ls_1 = 1) && (hs_2 - ls_2 = 1) then
       let range_size = ls_2 - ls_1 + 1 in
       let typ = TIndex ((0, u), (0, (range_size/u)))
-      in check_cmd body (Context.add_binding id typ ctx2, d2)
+      in check_cmd body (Context.add_binding id typ ctx2)
     else raise (TypeError range_static_error)
   | _ -> raise (TypeError range_error)
 
 (** [check_assignment id exp (c, d)] is [(c', d')], where [(c', d')]
  * contain a binding from [id] to the type of expression [exp] under
  * the context (c, d). *)
-and check_assignment id exp (ctx, delta) =
-  let (t, (c, d)) = check_expr exp (ctx, delta) in
-  (Context.add_binding id t c), d
+and check_assignment id exp ctx =
+  let (t, c) = check_expr exp ctx in
+  Context.add_binding id t c
 
 (** [check_reassign target exp (c, d)] is an updated context [(c', d')],
  * resulting from type-checking [target] and [exp]. [target] could be:
  *   - an array access, banked or not
  *   - a variable that already is bound *)
-and check_reassign target exp (ctx, delta) =
+and check_reassign target exp ctx =
   match target, exp with
   | EBankedAA (id, idx1, idx2), _ ->
-    check_banked_aa id idx1 idx2 (ctx, delta) |> fun (t_arr, (c, d)) ->
-    check_expr exp (c, d)                     |> fun (t_exp, (c', d')) ->
-    if types_equal delta t_arr t_exp then (c', d')
+    check_banked_aa id idx1 idx2 ctx |> fun (t_arr, c) ->
+    check_expr exp c                 |> fun (t_exp, c') ->
+    if types_equal t_arr t_exp then c'
     else raise @@ TypeError (unexpected_type id t_exp t_arr)
-  | EVar _, _ -> (ctx, delta)
+  | EVar _, _ -> ctx
   | EAA (id, idx), _ ->
-    snd @@ check_aa id idx (ctx, delta)
+    snd @@ check_aa id idx ctx
   | _ -> raise (TypeError "Used reassign operator on illegal types")
 
 (** [check_funcdef id args body (ctx, delta)] is [(ctx', delta')], where
@@ -188,35 +190,33 @@ and check_reassign target exp (ctx, delta) =
        the function with type [ti]. The order of the list implies the order
        of the function arguments.
      - [body] is a command representing the body of the function. *)
-and check_funcdef id args body (ctx, delta) =
+and check_funcdef id args body ctx =
   let add_argbind = fun ctx (arg_id, t) -> Context.add_binding arg_id t ctx in
   let context' = List.fold_left add_argbind ctx args in
-  let context'', delta' = check_cmd body (context', delta) in
+  let context'' = check_cmd body context' in
   let argtypes = List.map (fun (_, t) -> t) args in
-  Context.add_binding id (TFunc argtypes) context'', delta'
+  Context.add_binding id (TFunc argtypes) context''
 
 (** [check_app id args (c, d)] is [(c', d')], where [(c', d')] is the
  * context resulting from type-checking the function with identifier [id] with
  * the arguments represented by [args], where [args] an expression list. *)
-and check_app id args (ctx, delta) =
+and check_app id args ctx =
   let check_params arg param =
-    if not (types_equal delta arg param)
+    if not (types_equal arg param)
     then raise @@ TypeError (
       unexpected_type ("in function app of " ^ id ^ ", arg was") arg param)
     else () in
-  let argtypes = List.map (fun a -> fst @@ check_expr a (ctx, delta)) args in
+  let argtypes = List.map (fun a -> fst @@ check_expr a ctx) args in
   match Context.get_binding id ctx with
-  | TFunc param_types -> List.iter2 check_params argtypes param_types; (ctx, delta)
-  | _ -> raise (TypeError (illegal_app id))
-
-(** [check_typedef id t (c, d)] is [(c, d')], where [d'] is an updated delta with
- * a new binding from [id] to [t]. *)
-and check_typedef id t (ctx, delta) = ctx, (Context.add_alias_binding id t delta)
+  | TFunc param_types -> List.iter2 check_params argtypes param_types; ctx
+  | _ -> raise @@ TypeError (illegal_app id)
 
 (** [check_muxdef mux_id a_id size (c, d)] produces a context [(c', d')] containing
  * a new binding from [id] to [TMux (a_id, size)], where:
  *   - [m_id] is the id of a multiplexer
  *   - [a_id] is the id of the memory encapsulated by mux [m_id]
      - [size] is the number of inputs for the mux [m_id] *)
-and check_muxdef mux_id a_id size (ctx, delta) =
-  Context.add_binding mux_id (TMux (a_id, size)) ctx, delta
+and check_muxdef mux_id a_id size ctx =
+  Context.add_binding mux_id (TMux (a_id, size)) ctx
+
+let typecheck cmd : gamma = check_cmd cmd empty_gamma

--- a/src/type.mli
+++ b/src/type.mli
@@ -3,6 +3,5 @@ open Context
 
 exception TypeError of string
 
-val check_expr : expr -> (gamma * delta) -> type_node * (gamma * delta)
-
-val check_cmd : command -> (gamma * delta) -> (gamma * delta)
+(** Typechecks the command and returns the final type environment. *)
+val typecheck : command -> gamma

--- a/test/test_programs.ml
+++ b/test/test_programs.ml
@@ -97,7 +97,6 @@ let%expect_test "should-compile/multaccess.sea" =
 let%expect_test "should-compile/typedefs.sea" =
   compile "should-compile/typedefs.sea";
   [%expect {|
-    typedef int number;
     void add(int a, int b) {
 
     	int x = a+b;

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -5,8 +5,9 @@ open Compile_utils
 let compile_string prog =
   Printexc.record_backtrace false;
   let ast = parse_with_error prog in
-  let (ctx, dta) = typecheck_with_error ast in
-  emit_code ast ctx dta
+  let rast = Resolve_alias.remove_aliases ast in
+  let ctx = typecheck_with_error rast in
+  emit_code rast ctx
 
 let compile filename =
   let prog = In_channel.read_all filename in

--- a/test/type_test.ml
+++ b/test/type_test.ml
@@ -30,9 +30,6 @@ let%expect_test "boolean" =
     int y = 0; |}]
 ;;
 
-let%expect_test "type aliases" =
+let%expect_test "type aliases get erased" =
   compile_string "type b = bool; type i = int; type x = i;";
-  [%expect {|
-    typedef float b;
-    typedef int i;
-    typedef int x; |}]
+  [%expect {| |}]


### PR DESCRIPTION
Fixes #6.

This branch adds a new pass called `resolve_alias` that runs before the typechecker and replaces all instances of a `TAlias` with the exact type in the environment. This simplifies all the other phases which no longer need to handle the complicated delta threading logic.