### PR TITLE
Run buildbot worker threads in a separate process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ EXPOSE 8000
 ENV PIPENV_PIPFILE=buildbot/Pipfile
 CMD ["pipenv", "run", \
      "gunicorn", "--bind", "0.0.0.0:8000", "--chdir", "buildbot", \
-     "buildbot:app"]
+     "buildbot.server:app"]
 
 # Add Seashell source.
 ADD . seashell

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -4,7 +4,9 @@ dev:
 	FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
 
 serve:
-	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app
+	pipenv run python -m buildbot.workproc &
+	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app &
+	wait
 
 clean:
 	rm -rf instance

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -4,9 +4,7 @@ dev:
 	FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
 
 serve:
-	pipenv run python -m buildbot.workproc &
-	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app &
-	wait
+	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app
 
 clean:
 	rm -rf instance

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -1,7 +1,7 @@
 .PHONY: run clean
 
 dev:
-	FLASK_APP=buildbot.server FLASK_DEBUG=1 pipenv run flask run
+	FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
 
 serve:
 	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -1,10 +1,10 @@
 .PHONY: run clean
 
 dev:
-	FLASK_APP=buildbot FLASK_DEBUG=1 pipenv run flask run
+	FLASK_APP=buildbot.server FLASK_DEBUG=1 pipenv run flask run
 
 serve:
-	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot:app
+	pipenv run gunicorn --bind 0.0.0.0:8000 buildbot.server:app
 
 clean:
 	rm -rf instance

--- a/buildbot/Pipfile
+++ b/buildbot/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 gunicorn = "*"
+curio = "*"
 
 [dev-packages]
 

--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -10,7 +10,7 @@ Running the Buildbot
 To run your own server, get [pipenv][], then type `pipenv install`.
 Then, to run a local server:
 
-    $ FLASK_APP=buildbot pipenv run flask run
+    $ FLASK_APP=buildbot.server pipenv run flask run
 
 You can also use `make dev` as a shortcut (with debugging enabled).
 Also, `make serve` runs a production server using [Gunicorn][].

--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -7,17 +7,36 @@ This is a server for building and running Seashell programs on our infrastructur
 Running the Buildbot
 --------------------
 
-To run your own server, get [pipenv][], then type `pipenv install`.
-Then, to run a local server:
+To set things up, get [pipenv][], and then type `pipenv install`.
 
-    $ FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
-
-You can also use `make dev` as a shortcut (with debugging enabled).
-Also, `make serve` runs a production server using [Gunicorn][].
+To use the "live" browser interface, you will also need to get [Yarn][] (or [npm][]) and type `yarn` then `yarn build` to set up the necessary JavaScript.
 
 The server keeps the data, including the database and the file trees for each job, in an `instance` directory here.
 
-To use the "live" browser interface, you will also need to get [Yarn][] (or [npm][]) and type `yarn` then `yarn build` to set up the necessary JavaScript.
+We have different recommendations depending on whether you're running the buildbot locally (for development) or on a proper server.
+
+### Development
+
+Then, run this command to get a development server:
+
+    $ FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
+
+You can also use `make dev` as a shortcut.
+This route automatically starts the necessary worker threads in the same process as the development server.
+
+### Deployment
+
+There are two differences in deployment: you'll want to use a proper server, and you'll want to run the worker threads manually in a separate process.
+
+To start the worker threads, use this command:
+
+    $ pipenv run python -m buildbot.workproc
+
+For the server, [Gunicorn][] is a good choice (and included in the dependencies). Here's how you might invoke it:
+
+    $ pipenv run gunicorn buildbot.server:app
+
+See the `make serve` target in the `Makefile` for an example that launches both processes together in a process group.
 
 [gunicorn]: http://gunicorn.org
 [pipenv]: http://pipenv.org

--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -10,7 +10,7 @@ Running the Buildbot
 To run your own server, get [pipenv][], then type `pipenv install`.
 Then, to run a local server:
 
-    $ FLASK_APP=buildbot.server pipenv run flask run
+    $ FLASK_APP=buildbot.server FLASK_ENV=development pipenv run flask run
 
 You can also use `make dev` as a shortcut (with debugging enabled).
 Also, `make serve` runs a production server using [Gunicorn][].

--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -26,17 +26,20 @@ This route automatically starts the necessary worker threads in the same process
 
 ### Deployment
 
-There are two differences in deployment: you'll want to use a proper server, and you'll want to run the worker threads manually in a separate process.
-
-To start the worker threads, use this command:
-
-    $ pipenv run python -m buildbot.workproc
+There are two differences in deployment: you'll want to use a proper server, and the buildbot will want to spawn a separate process just for the worker threads.
 
 For the server, [Gunicorn][] is a good choice (and included in the dependencies). Here's how you might invoke it:
 
     $ pipenv run gunicorn buildbot.server:app
 
-See the `make serve` target in the `Makefile` for an example that launches both processes together in a process group.
+The `make serve` target does that.
+The server process will automatically spawn the worker subprocess by default.
+If you would rather manage it independently, disable the `WORKER_PROCESS` configuration and use this command to launch the workers:
+
+    $ pipenv run python -m buildbot.workproc
+
+The two processes communicate through a Unix domain socket in the instance directory.
+You can provide a custom instance directory path to the workproc invocation as an argument.
 
 [gunicorn]: http://gunicorn.org
 [pipenv]: http://pipenv.org

--- a/buildbot/buildbot/__init__.py
+++ b/buildbot/buildbot/__init__.py
@@ -1,1 +1,0 @@
-from .server import app  # noqa

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -1,6 +1,15 @@
+# The extensions to allow for uploaded code archives.
 UPLOAD_EXTENSIONS = ['zip']
+
+# The executable name for the Seashell compiler (seac).
 SEASHELL_COMPILER = 'seac'
+
+# A prefix command to use *before* the invocations of Xilinx tools.
 HLS_COMMAND_PREFIX = []
+
+# Spawn threads inside the server process for the workers (instead of
+# using a separate worker process).
+WORKER_THREADS = True
 
 # Filename extensions to send as plain text for job file viewing.
 TEXT_EXTENSIONS = [

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -12,6 +12,11 @@ HLS_COMMAND_PREFIX = []
 # development environment and False in production.
 WORKER_THREADS = None
 
+# Try to automatically launch a worker process if one is not already
+# running. We detect a running worker process using the presence of the
+# Unix domain socket. (This has no effect if WORKER_THREADS is True.)
+WORKER_PROCESS = True
+
 # Filename extensions to send as plain text for job file viewing.
 TEXT_EXTENSIONS = [
     'ss',

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -8,8 +8,9 @@ SEASHELL_COMPILER = 'seac'
 HLS_COMMAND_PREFIX = []
 
 # Spawn threads inside the server process for the workers (instead of
-# using a separate worker process).
-WORKER_THREADS = True
+# using a separate worker process). The default (None) means True in the
+# development environment and False in production.
+WORKER_THREADS = None
 
 # Filename extensions to send as plain text for job file viewing.
 TEXT_EXTENSIONS = [

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -59,11 +59,17 @@ def start_workers():
     In WORKER_THREADS mode, start a bunch of threads *in this process*
     to do the work. This is *not safe* if there might be multiple server
     processes or threads, which will all start different copies of the
-    worker threads! Otherwise, we will use an existing workproc.
+    worker threads!
+
+    Otherwise, in WORKER_PROCESS mode, try starting the workproc if it
+    does not already seem to be running (as evidenced by the presence of
+    its Unix domain socket).
     """
     if app.config['WORKER_THREADS']:
         proc = workproc.WorkProc(app.instance_path, db)
         proc.start()
+    elif app.config['WORKER_PROCESS']:
+        workproc.launch(app.instance_path)
 
 
 def notify_workers(jobname):

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -58,7 +58,7 @@ def start_workers():
     worker threads! Otherwise, we will use an existing workproc.
     """
     if app.config['WORKER_THREADS']:
-        proc = workproc.WorkProc(app.instance_path)
+        proc = workproc.WorkProc(app.instance_path, db)
         proc.start()
 
 

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -15,6 +15,10 @@ app = flask.Flask(__name__, instance_relative_config=True)
 app.config.from_object('buildbot.config_default')
 app.config.from_pyfile('buildbot.cfg', silent=True)
 
+# Use worker threads by default in development.
+if app.config['WORKER_THREADS'] is None:
+    app.config['WORKER_THREADS'] = (app.env == 'development')
+
 # Connect to our database.
 db = JobDB(app.instance_path)
 

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -70,19 +70,17 @@ def add_job():
             return 'invalid extension {}'.format(ext), 400
 
         # Create the job and save the archive file.
-        with db.create('uploading', 'uploaded') as job:
+        with db.create('uploaded') as name:
             file.save(ARCHIVE_NAME + ext)
-            name = job['name']
 
     elif 'code' in request.values:
         code = request.values['code']
 
         # Create a job and save the code to a file.
-        with db.create('uploading', 'unpacked') as job:
+        with db.create('unpacked') as name:
             os.mkdir(CODE_DIR)
             with open(os.path.join(CODE_DIR, 'main.ss'), 'w') as f:
                 f.write(code)
-            name = job['name']
 
     else:
         return 'missing code or file', 400

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -155,7 +155,6 @@ def stage_unpack(db, config):
     """
     with work(db, 'uploaded', 'unpacking', 'unpacked') as job:
         # Unzip the archive into the code directory.
-        print("Starting to unzip")
         runl(job, ["unzip", "-d", CODE_DIR, "{}.zip".format(ARCHIVE_NAME)])
 
         # Check for single-directory zip files: if the code directory
@@ -164,7 +163,6 @@ def stage_unpack(db, config):
         if len(code_contents) == 1:
             path = os.path.join(CODE_DIR, code_contents[0])
             if os.path.isdir(path):
-                print(path, os.listdir(path))
                 for fn in os.listdir(path):
                     os.rename(os.path.join(path, fn),
                               os.path.join(CODE_DIR, fn))

--- a/buildbot/buildbot/workproc.py
+++ b/buildbot/buildbot/workproc.py
@@ -1,0 +1,23 @@
+import curio
+import os
+
+
+async def handle(client, addr):
+    print('connected')
+    while True:
+        async for line in client.makefile('rb'):
+            print(line)
+    print('closed')
+
+
+def workproc(sockpath='workproc.sock'):
+    try:
+        curio.run(curio.unix_server, sockpath, handle)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        os.unlink(sockpath)
+
+
+if __name__ == '__main__':
+    workproc()

--- a/buildbot/buildbot/workproc.py
+++ b/buildbot/buildbot/workproc.py
@@ -2,22 +2,25 @@ import curio
 import os
 
 
-async def handle(client, addr):
-    print('connected')
-    while True:
-        async for line in client.makefile('rb'):
-            print(line)
-    print('closed')
+class WorkProc:
+    async def handle(self, client, addr):
+        """Handle an incoming socket connection.
+        """
+        while True:
+            async for line in client.makefile('rb'):
+                print(line)
 
-
-def workproc(sockpath='workproc.sock'):
-    try:
-        curio.run(curio.unix_server, sockpath, handle)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        os.unlink(sockpath)
+    def serve(self, sockpath='workproc.sock'):
+        """Start listening on a Unix domain socket for incoming
+        messages. Run indefinitely (until the server is interrupted).
+        """
+        try:
+            curio.run(curio.unix_server, sockpath, self.handle)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            os.unlink(sockpath)
 
 
 if __name__ == '__main__':
-    workproc()
+    WorkProc().serve()

--- a/buildbot/buildbot/workproc.py
+++ b/buildbot/buildbot/workproc.py
@@ -1,7 +1,7 @@
 import curio
 import os
 from . import worker
-from . import db
+from .db import JobDB
 from flask.config import Config
 import sys
 
@@ -15,7 +15,12 @@ class WorkProc:
     notifications from a Unix domain socket.
     """
 
-    def __init__(self, basedir):
+    def __init__(self, basedir, db=None):
+        """Create a container using a given base directory for the
+        storage and socket. Optionally, provide a database object to use
+        that instead of creating a new one (to, for example, reuse its
+        internal locks).
+        """
         self.basedir = basedir
 
         # Load the configuration. We're just reusing Flask's simple
@@ -25,7 +30,7 @@ class WorkProc:
         self.config.from_pyfile('buildbot.cfg', silent=True)
 
         # Create the database.
-        self.db = db.JobDB(basedir)
+        self.db = db or JobDB(basedir)
 
     def start(self):
         """Create and start the worker threads.

--- a/buildbot/buildbot/workproc.py
+++ b/buildbot/buildbot/workproc.py
@@ -21,16 +21,16 @@ class WorkProc:
         that instead of creating a new one (to, for example, reuse its
         internal locks).
         """
-        self.basedir = basedir
+        self.basedir = os.path.abspath(basedir)
 
         # Load the configuration. We're just reusing Flask's simple
         # configuration component here.
-        self.config = Config(basedir)
+        self.config = Config(self.basedir)
         self.config.from_object('buildbot.config_default')
         self.config.from_pyfile('buildbot.cfg', silent=True)
 
         # Create the database.
-        self.db = db or JobDB(basedir)
+        self.db = db or JobDB(self.basedir)
 
     def start(self):
         """Create and start the worker threads.

--- a/buildbot/buildbot/workproc.py
+++ b/buildbot/buildbot/workproc.py
@@ -30,7 +30,13 @@ class WorkProc:
         """
         while True:
             async for line in client.makefile('rb'):
-                print(line)
+                # Each line is a job name.
+                job_name = line.decode('utf8').strip()
+                print(job_name)
+
+                # Just notify the database that something changed.
+                with self.db.cv:
+                    self.db.cv.notify_all()
 
     def serve(self, sockpath='workproc.sock'):
         """Start listening on a Unix domain socket for incoming


### PR DESCRIPTION
This strategy uses a persistent, external process to execute the worker threads instead of running them in the same process as the Web server. In addition to being aesthetically nicer, this solves some important concurrency bugs where the server would kill workers without warning and we would sometimes have too many copies of the worker threads.

I'm pretty sure this is all working (works fine on my machine!), but I'll hold off on merging for now until I can try it out on Gorgonzola, which out through the weekend to expand its disk capacity.