### PR TITLE
Arbitrary precision integers v2!

### DIFF
--- a/src/emit.ml
+++ b/src/emit.ml
@@ -45,8 +45,11 @@ let type_str = function
   | TIndex (_, (_, hs)) ->
     let bits_st =
       if hs=1 (* static number, don't annotate *) then ""
-      else Core.Int.floor_log2 hs |> string_of_int
-    in concat [ "uint"; bits_st ]
+      else Core.Int.floor_log2 hs |> string_of_int in
+    let int_st =
+      if hs=1 then "int"
+      else "uint" in
+    concat [ int_st; bits_st ]
   | TFloat -> "float"
   | t -> failwith (Printf.sprintf "Cannot emit type %s." (show_type_node t))
 

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -23,6 +23,8 @@ let concat = String.concat ""
 
 let comment s = Printf.sprintf "/* %s */" s
 
+let incl_apint = {|#include "apcint.h"|}
+
 let s_pragma_unroll u i =
   if u = "1" then ""
   else concat [ "#pragma HLS UNROLL factor="; u ] |> indent i
@@ -39,7 +41,12 @@ let compute_array_size dims =
   List.fold_left (fun acc (s, _) -> s * acc) 1 dims
 
 let type_str = function
-  | TBool | TIndex _ -> "int"
+  | TBool -> "int"
+  | TIndex (_, (_, hs)) ->
+    let bits_st =
+      if hs=1 (* static number, don't annotate *) then ""
+      else Core.Int.floor_log2 hs |> string_of_int
+    in concat [ "int"; bits_st ]
   | TFloat -> "float"
   | t -> failwith (Printf.sprintf "Cannot emit type %s." (show_type_node t))
 
@@ -127,8 +134,8 @@ and emit_cap (cap, e, _) i = match cap with
 
 and emit_mux _ = failwith "Muxes not implemented"
 
-and emit_assign_int (id, e) =
-  concat [ "int "; id; " = "; (emit_expr e); ";" ]
+and emit_assign_int (id, e, typ_s) =
+  concat [ typ_s; " "; id; " = "; (emit_expr e); ";" ]
 
 and emit_assign_arr (id, _, d) i =
   let bf = compute_bf d in
@@ -146,12 +153,12 @@ and emit_assign_float (id, e) =
 
 and emit_assign (id, e) i =
   match !type_map id with
-  | TIndex _      -> emit_assign_int (id, e)         |> indent i
-  | TBool         -> emit_assign_int (id, e)         |> indent i
-  | TArray (_, d) -> emit_assign_arr (id, e, d) i    |> indent i
-  | TFloat        -> emit_assign_float (id, e)       |> indent i
-  | TAlias _      -> failwith "Impossible: TAlias while emitting"
-  | t             -> failwith @@ "NYI: emit_assign with " ^ show_type_node t
+  | TIndex _ as idx -> emit_assign_int (id, e, (type_str idx)) |> indent i
+  | TBool           -> emit_assign_int (id, e, "int")          |> indent i
+  | TArray (_, d)   -> emit_assign_arr (id, e, d) i            |> indent i
+  | TFloat          -> emit_assign_float (id, e)               |> indent i
+  | TAlias _        -> failwith "Impossible: TAlias while emitting"
+  | t               -> failwith @@ "NYI: emit_assign with " ^ show_type_node t
 
 and emit_reassign (target, e) i =
   concat [ (emit_expr target); " = "; (emit_expr e); ";" ] |> indent i
@@ -195,4 +202,4 @@ and emit_fun (id, args, body) i =
   |> indent i
 
 and generate_c cmd =
-  emit_cmd 0 cmd |> cleanup_output
+  concat [ incl_apint; newline; (emit_cmd 0 cmd |> cleanup_output) ]

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -46,7 +46,7 @@ let type_str = function
     let bits_st =
       if hs=1 (* static number, don't annotate *) then ""
       else Core.Int.floor_log2 hs |> string_of_int
-    in concat [ "int"; bits_st ]
+    in concat [ "uint"; bits_st ]
   | TFloat -> "float"
   | t -> failwith (Printf.sprintf "Cannot emit type %s." (show_type_node t))
 

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -105,8 +105,8 @@ let invalid_array_write id =
 
 let reassign_bit_violation s_target s_val =
   sprintf
-    {| Can't reassign value of type `%s' to value of type `%s'; `%s' is\n
-       represented with less bits than `%s'. |}
+    "[Type Error] Cannot reassign value of type `%s' to value of type `%s';
+     `%s' is represented with less bits than `%s'."
   (string_of_type s_target)
   (string_of_type s_val)
   (string_of_type s_target)

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -3,13 +3,30 @@ open Printf
 
 exception TypeError of string
 
+(* [is_ubit d] is:
+ *  - [true] if [d] is (0, 2^n) for some n
+    - [false] otherwise *)
+let is_ubit d =
+  ignore (d); failwith "NYI"
+
+(* [pprint_idx s d] is a string representation of the index type
+ * [TIndex (s, d)), which is:
+ *  - unsigned bit<n> if [s] is (0, 1), and [d] is (0..2^n)
+ *  - idx<...> otherwise *)
+let pprint_idx s d =
+  let (ls, hs), (ld, hd) = s, d in
+    if (ls, hs) = (0, 1) && is_ubit d then
+      sprintf "unsigned bit<%s>" @@ string_of_int (Core.Int.floor_log2 hd)
+    else sprintf "idx<%s..%s, %s..%s>"
+      (string_of_int ls)
+      (string_of_int hs)
+      (string_of_int ld)
+      (string_of_int hd)
+
 let rec string_of_type = function
   | TBool -> "bool"
   | TArray (t, _) -> (string_of_type t) ^ " array"
-  | TIndex (s, d) ->
-    let (ls, hs), (ld, hd) = s, d in
-    sprintf "idx<%s..%s, %s..%s>"
-      (string_of_int ls) (string_of_int hs) (string_of_int ld) (string_of_int hd)
+  | TIndex (s, d) -> pprint_idx s d
   | TAlias id -> id
   | TFloat -> "float"
   | TFunc _ -> "func"

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -7,7 +7,7 @@ exception TypeError of string
  *  - [true] if [d] is (0, 2^n) for some n
     - [false] otherwise *)
 let is_ubit (ld, hd) =
-  ld=0 && hd <> 0 && (hd land hd-1) = 0
+  ld=0 && hd <> 0 && hd land (hd-1) = 0
 
 (* [pprint_idx s d] is a string representation of the index type
  * [TIndex (s, d)), which is:

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -102,3 +102,13 @@ let incorrect_aa_dims aname expected actual =
 
 let invalid_array_write id =
   sprintf "Cannot write into array `%s' without write capability." id
+
+let reassign_bit_violation s_target s_val =
+  sprintf
+    {| Can't reassign value of type `%s' to value of type `%s'; `%s' is\n
+       represented with less bits than `%s'. |}
+  (string_of_type s_target)
+  (string_of_type s_val)
+  (string_of_type s_target)
+  (string_of_type s_val)
+

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -6,8 +6,8 @@ exception TypeError of string
 (* [is_ubit d] is:
  *  - [true] if [d] is (0, 2^n) for some n
     - [false] otherwise *)
-let is_ubit d =
-  ignore (d); failwith "NYI"
+let is_ubit (ld, hd) =
+  ld=0 && hd <> 0 && (hd land hd-1) = 0
 
 (* [pprint_idx s d] is a string representation of the index type
  * [TIndex (s, d)), which is:

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -55,6 +55,7 @@ rule token =
   | "unroll"     { UNROLL }
   | "func"       { FUNC }
   | "type"       { TYPE }
+  | "bit"        { BIT }
 
   | "int"        { INT_ANNOTATION }
   | "bool"       { BOOL_ANNOTATION }

--- a/src/op_util.ml
+++ b/src/op_util.ml
@@ -2,37 +2,54 @@ open Ast
 
 exception IllegalOperation
 
-(* Index types generalize integers. We have not completely figured
-   out operations between index types; but we'd like to allow normal
-   integer operations between integers. [resolve_index_op t1 t2]
-   allows operations between index types that represent *one* value
-   at a particular moment, so the static component has cardinality one.
-   The resulting type is currently set to be a signed dynamic integer of
-   type idx<0..1, min_int..max_int>. This lets us add dynamic integers,
-   static integers, etc., but disallows operations between sets of values. *)
-let resolve_index_op t1 t2 =
+(* [compute_n a b op] is the result of evaluating the binary
+ * operation [op] on [a] and [b]. Helper for [resolve_index_op].
+ * Raises [Failure _] if [op] is not some arithmetic binop. *)
+let compute_n (a: int) (b: int) (op: binop) =
+  match op with
+  | BopPlus  -> a + b
+  | BopMinus -> a - b
+  | BopTimes -> a * b
+  | _        ->
+    failwith "Impossible case. Boolean operations handled in op_map."
+
+(* [resolve_index_op t1 t2 op] is [TIndex ((ls, hs), (ld, hd)),
+ * where:
+ *  - [ld] is the lesser of the dynamic component lower bounds
+ *    of [t1] and [t2]
+ *  - [hd] is the greater of the dynamic component upper bounds
+ *    of [t1] and [t2]
+ *  - (ls, hs) is (n, n+1), where n = (op) ls1 ls2
+ * Raises [IllegalOperation] if [t1] or [t2] have non-trivial
+ * static components, i.e. something other than (i, i+1) for
+ * some i. *)
+let resolve_index_op t1 t2 op =
   match t1, t2 with
-  | ((ls1, hs1), _), ((ls2, hs2), _) ->
+  | ((ls1, hs1), (ld1, hd1)), ((ls2, hs2), (ld2, hd2)) ->
     if
       hs1 - ls1 = 1 (* t1 represents one int *) &&
       hs2 - ls2 = 1 (* t2 represents one int *)
-    then TIndex ((ls1, hs1), (min_int, max_int))
+    then
+      let n  = compute_n ls1 ls2 op in
+      let ld = min ld1 ld2 in
+      let hd = max hd1 hd2 in
+      TIndex ((n, n+1), (ld, hd))
     else raise IllegalOperation
 
 let op_map a b op =
   match a, b, op with
-  | _, _, BopEq                         -> TBool
-  | _, _, BopNeq                        -> TBool
-  | _, _, BopGeq                        -> TBool
-  | _, _, BopLeq                        -> TBool
-  | _, _, BopLt                         -> TBool
-  | _, _, BopGt                         -> TBool
-  | TFloat, TFloat, BopPlus             -> TFloat
-  | TFloat, TFloat, BopMinus            -> TFloat
-  | TFloat, TFloat, BopTimes            -> TFloat
-  | _, _, BopAnd                        -> TBool
-  | _, _, BopOr                         -> TBool
-  | TIndex (s1, d1), TIndex (s2, d2), _ -> resolve_index_op (s1, d1) (s2, d2)
-  | _                                   -> raise IllegalOperation
+  | _, _, BopEq                          -> TBool
+  | _, _, BopNeq                         -> TBool
+  | _, _, BopGeq                         -> TBool
+  | _, _, BopLeq                         -> TBool
+  | _, _, BopLt                          -> TBool
+  | _, _, BopGt                          -> TBool
+  | TFloat, TFloat, BopPlus              -> TFloat
+  | TFloat, TFloat, BopMinus             -> TFloat
+  | TFloat, TFloat, BopTimes             -> TFloat
+  | _, _, BopAnd                         -> TBool
+  | _, _, BopOr                          -> TBool
+  | TIndex (s1, d1), TIndex (s2, d2), op -> resolve_index_op (s1, d1) (s2, d2) op
+  | _                                    -> raise IllegalOperation
 
 let type_of_op a b op = op_map a b op

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -19,7 +19,7 @@ let parse_sequence c1 c2 =
 (* Keywords *)
 %token LET IF FOR TRUE FALSE INT_ANNOTATION
        BOOL_ANNOTATION FLOAT_ANNOTATION
-       MUX UNROLL BANK FUNC TYPE WRITE READ AS
+       MUX UNROLL BANK FUNC TYPE WRITE READ AS BIT
 
 (* Parentheses, brackets, etc *)
 %token LPAREN RPAREN LBRACK RBRACK LSQUARE RSQUARE
@@ -95,7 +95,11 @@ access:
   | LSQUARE expr RSQUARE          { [$2] }
   | LSQUARE expr RSQUARE access   { $2 :: $4 }
 
+bit_annotation:
+  | BIT LT i = INT GT { i }
+
 basic_type:
+  | bit_annotation              { print_int $1; print_newline (); TIndex ((0, 1), (0, Core.Int.pow 2 $1)) }
   | BOOL_ANNOTATION             { TBool }
   | INT_ANNOTATION              { TIndex ((0, 1), (min_int, max_int)) }
   | FLOAT_ANNOTATION            { TFloat }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -96,12 +96,11 @@ access:
   | LSQUARE expr RSQUARE access   { $2 :: $4 }
 
 bit_annotation:
-  | BIT LT i = INT GT { i }
+  | BIT LT INT GT { $3 }
 
 basic_type:
-  | bit_annotation              { print_int $1; print_newline (); TIndex ((0, 1), (0, Core.Int.pow 2 $1)) }
+  | bit_annotation              { TIndex ((0, 1), (0, Core.Int.pow 2 $1)) }
   | BOOL_ANNOTATION             { TBool }
-  | INT_ANNOTATION              { TIndex ((0, 1), (min_int, max_int)) }
   | FLOAT_ANNOTATION            { TFloat }
   | ID                          { TAlias $1 }
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -160,10 +160,6 @@ and check_assignment id exp ctx =
 and check_bitsizes t1 t2 =
   match t1, t2 with
   | TIndex (_, (ld1, hd1)), TIndex (_, (ld2, hd2)) ->
-    print_int (hd1-ld1);
-    print_newline ();
-    print_int (hd2-ld2);
-    print_newline ();
     if hd1-ld1 < hd2-ld2 then
       raise @@ TypeError (reassign_bit_violation t1 t2)
   | _ -> ()

--- a/test/should-compile/typedefs.sea
+++ b/test/should-compile/typedefs.sea
@@ -1,4 +1,4 @@
-type number = int;
+type number = bit<32>;
 
 func add(a: number, b: number) {
 

--- a/test/should-compile/vsadd_nrl.sea
+++ b/test/should-compile/vsadd_nrl.sea
@@ -5,7 +5,7 @@
 ////////////////////////////////////////////
 
 
-func madd(a: int[1024 bank(32)], b: int, c: int[1024 bank(32)]) {
+func madd(a: bit<32>[1024 bank(32)], b: bit<32>, c: bit<32>[1024 bank(32)]) {
 
   for (let i = 0..31) {
     c{0}[i] := a{0}[i] + b;

--- a/test/test_programs.ml
+++ b/test/test_programs.ml
@@ -5,6 +5,7 @@ open Test_utils
 let%expect_test "should-compile/vsadd.sea" =
   compile "should-compile/vsadd.sea";
   [%expect {|
+    #include "apcint.h"
     void madd(float a[1024], float b, float c[1024]) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       #pragma HLS ARRAY_PARTITION variable=c factor=32
@@ -20,6 +21,7 @@ let%expect_test "should-compile/vsadd.sea" =
 let%expect_test "should-compile/array1d_logical.sea" =
   compile "should-compile/array1d_logical.sea";
   [%expect {|
+    #include "apcint.h"
     void madd(float a[1024], float b) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       for (int i = 0; i <= 1023; i += 1) {
@@ -33,6 +35,7 @@ let%expect_test "should-compile/array1d_logical.sea" =
 let%expect_test "should-compile/array1d_physical.sea" =
   compile "should-compile/array1d_physical.sea";
   [%expect {|
+    #include "apcint.h"
     void madd(float a[1024], float b, float c) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       for (int i = 0; i <= 31; i += 1) {
@@ -47,6 +50,7 @@ let%expect_test "should-compile/array1d_physical.sea" =
 let%expect_test "should-compile/crlf.sea" =
   compile "should-compile/crlf.sea";
   [%expect {|
+    #include "apcint.h"
     void add(float a, float b) {
       float c = a+b;
     } |}]
@@ -55,6 +59,7 @@ let%expect_test "should-compile/crlf.sea" =
 let%expect_test "should-compile/float.sea" =
   compile "should-compile/float.sea";
   [%expect {|
+    #include "apcint.h"
     void add_floats(float a, float b) {
       float x = 2.5;
       float z = a+b+x;
@@ -64,17 +69,19 @@ let%expect_test "should-compile/float.sea" =
 let%expect_test "should-compile/typedefs.sea" =
   compile "should-compile/typedefs.sea";
   [%expect {|
-    void add(int a, int b) {
-      int x = a+b;
+    #include "apcint.h"
+    void add(int32 a, int32 b) {
+      int32 x = a+b;
       int y = 5;
-      int z = a+b+x+y;
+      int32 z = a+b+x+y;
     } |}]
 ;;
 
 let%expect_test "should-compile/vsadd_nrl.sea" =
   compile "should-compile/vsadd_nrl.sea";
   [%expect {|
-    void madd(int a[1024], int b, int c[1024]) {
+    #include "apcint.h"
+    void madd(int32 a[1024], int32 b, int32 c[1024]) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       #pragma HLS ARRAY_PARTITION variable=c factor=32
       for (int i = 0; i <= 31; i += 1) {
@@ -91,6 +98,7 @@ let%expect_test "should-compile/vsadd_nrl.sea" =
 let%expect_test "should-compile/vvadd.sea" =
   compile "should-compile/vvadd.sea";
   [%expect {|
+    #include "apcint.h"
     void madd(float a[1024], float b[1024], float c[1024]) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       #pragma HLS ARRAY_PARTITION variable=b factor=32

--- a/test/test_programs.ml
+++ b/test/test_programs.ml
@@ -70,10 +70,10 @@ let%expect_test "should-compile/typedefs.sea" =
   compile "should-compile/typedefs.sea";
   [%expect {|
     #include "apcint.h"
-    void add(int32 a, int32 b) {
-      int32 x = a+b;
+    void add(uint32 a, uint32 b) {
+      uint32 x = a+b;
       int y = 5;
-      int32 z = a+b+x+y;
+      uint32 z = a+b+x+y;
     } |}]
 ;;
 
@@ -81,7 +81,7 @@ let%expect_test "should-compile/vsadd_nrl.sea" =
   compile "should-compile/vsadd_nrl.sea";
   [%expect {|
     #include "apcint.h"
-    void madd(int32 a[1024], int32 b, int32 c[1024]) {
+    void madd(uint32 a[1024], uint32 b, uint32 c[1024]) {
       #pragma HLS ARRAY_PARTITION variable=a factor=32
       #pragma HLS ARRAY_PARTITION variable=c factor=32
       for (int i = 0; i <= 31; i += 1) {

--- a/test/type_failures.ml
+++ b/test/type_failures.ml
@@ -46,3 +46,9 @@ let%expect_test "Cannot shadow variables" =
   compile_string_with_failure "func foo(a: bit<32>[10]) { let a = 10; }";
   [%expect {|
     `a' already bound in this context. Cannot shadow variables. |}]
+
+let%expect_test "Cannot reassign int to something stored with more bits" =
+  compile_string_with_failure "func foo(a: bit<32>, b: bit<33>) { a := b; }";
+  [%expect {|
+    [Type Error] Cannot reassign value of type `unsigned bit<32>' to value of type `unsigned bit<33>';
+         `unsigned bit<32>' is represented with less bits than `unsigned bit<33>'.|}]

--- a/test/type_failures.ml
+++ b/test/type_failures.ml
@@ -8,19 +8,19 @@ let%expect_test "cannot add float and int" =
     [Type error] can't apply operator + to float and idx<3..4, 0..1>. |}]
 
 let%expect_test "Cannot access one dimensional array as multidimensional" =
-  compile_string_with_failure "func foo(a: int[10]) { a[1][1]; }";
+  compile_string_with_failure "func foo(a: bit<32>[10]) { a[1][1]; }";
   [%expect {|
     [Type Error] array `a' has 1 dimension; attempted array access implies 2 dimensions |}]
 
 let%expect_test "Cannot access non-existent bank" =
-  compile_string_with_failure "func foo(a: int[10], x: int) { a{1}[1]; }";
+  compile_string_with_failure "func foo(a: bit<32>[10], x: bit<32>) { a{1}[1]; }";
   [%expect {|
     [Type error] Bank 1 already consumed for memory `a' |}]
 
 let%expect_test "Cannot assign incorrect type to array" =
-  compile_string_with_failure "func foo(a: int[10], x: bool) { a[1] := x; }";
+  compile_string_with_failure "func foo(a: bit<32>[10], x: bool) { a[1] := x; }";
   [%expect {|
-    [Type Error] cannot assign value of type `bool' to L-value of type `idx<0..1, -4611686018427387904..4611686018427387903> lin'. |}]
+    [Type Error] cannot assign value of type `bool' to L-value of type `idx<0..1, 0..4294967296> lin'. |}]
 
 let%expect_test "Cannot reassign to different type" =
   compile_string_with_failure "let x = 2.5; x := 1;";
@@ -28,21 +28,21 @@ let%expect_test "Cannot reassign to different type" =
     [Type Error] cannot assign value of type `idx<1..2, 0..1>' to L-value of type `float'. |}]
 
 let%expect_test "Cannot write to array twice" =
-  compile_string_with_failure "func foo(a: int[10]) { a[1] := 1; a[1] := 1; }";
+  compile_string_with_failure "func foo(a: bit<32>[10]) { a[1] := 1; a[1] := 1; }";
   [%expect {|
     [Type error] Bank 0 already consumed for memory `a5' |}]
 
 let%expect_test "Cannot write to array twice with explicit cap" =
-  compile_string_with_failure "func foo(a: int[10]) { write a[1] as a1; a1 := 1; a1 := 1; }";
+  compile_string_with_failure "func foo(a: bit<32>[10]) { write a[1] as a1; a1 := 1; a1 := 1; }";
   [%expect {|
     [Type error] Bank 0 already consumed for memory `a1' |}]
 
 let%expect_test "Cannot read and write with same array" =
-  compile_string_with_failure "func foo(a: int[10]) { a[1] := 1; let x = a[1]; }";
+  compile_string_with_failure "func foo(a: bit<32>[10]) { a[1] := 1; let x = a[1]; }";
   [%expect {|
     [Type error] Bank 0 already consumed for memory `a' |}]
 
 let%expect_test "Cannot shadow variables" =
-  compile_string_with_failure "func foo(a: int[10]) { let a = 10; }";
+  compile_string_with_failure "func foo(a: bit<32>[10]) { let a = 10; }";
   [%expect {|
     `a' already bound in this context. Cannot shadow variables. |}]

--- a/test/type_failures.ml
+++ b/test/type_failures.ml
@@ -20,7 +20,7 @@ let%expect_test "Cannot access non-existent bank" =
 let%expect_test "Cannot assign incorrect type to array" =
   compile_string_with_failure "func foo(a: bit<32>[10], x: bool) { a[1] := x; }";
   [%expect {|
-    [Type Error] cannot assign value of type `bool' to L-value of type `idx<0..1, 0..4294967296> lin'. |}]
+    [Type Error] cannot assign value of type `bool' to L-value of type `unsigned bit<32> lin'. |}]
 
 let%expect_test "Cannot reassign to different type" =
   compile_string_with_failure "let x = 2.5; x := 1;";

--- a/test/type_test.ml
+++ b/test/type_test.ml
@@ -20,7 +20,7 @@ let%expect_test "boolean" =
     int y = 0; |}]
 
 let%expect_test "type aliases get erased" =
-  compile_string "type b = bool; type i = int; type x = i;";
+  compile_string "type b = bool; type i = bit<32>; type x = i;";
   [%expect {| |}]
 
 let%expect_test "Reassign variables" =
@@ -30,7 +30,7 @@ let%expect_test "Reassign variables" =
     x = 0; |}]
 
 let%expect_test "Reassign arrays" =
-  compile_string "func foo(a: int[10], b: int[10]) { a[0] := b[0]; }";
+  compile_string "func foo(a: bit<32>[10], b: bit<32>[10]) { a[0] := b[0]; }";
   [%expect {|
     void foo(int a[10], int b[10]) {
       /* cap read: b[1*(0)] */
@@ -39,7 +39,7 @@ let%expect_test "Reassign arrays" =
     } |}]
 
 let%expect_test "Read from array twice" =
-  compile_string "func foo(a: int[10]) { let x = a[1]; let y = a[1];}";
+  compile_string "func foo(a: bit<32>[10]) { let x = a[1]; let y = a[1];}";
   [%expect {|
     void foo(int a[10]) {
       /* cap read: a[1*(1)] */
@@ -48,7 +48,7 @@ let%expect_test "Read from array twice" =
     } |}]
 
 let%expect_test "Read from array twice with explicit capability" =
-  compile_string "func foo(a: int[10]) { read a[1] as a1; let x = a1; let y = a1;}";
+  compile_string "func foo(a: bit<32>[10]) { read a[1] as a1; let x = a1; let y = a1;}";
   [%expect {|
     void foo(int a[10]) {
       /* cap read: a[1*(1)] */
@@ -57,7 +57,7 @@ let%expect_test "Read from array twice with explicit capability" =
     } |}]
 
 let%expect_test "Write to an array with explicit capability" =
-  compile_string "func foo(a: int[10]) { write a[1] as a1; a1 := 1;}";
+  compile_string "func foo(a: bit<32>[10]) { write a[1] as a1; a1 := 1;}";
   [%expect {|
     void foo(int a[10]) {
       /* cap write: a[1*(1)] */

--- a/test/type_test.ml
+++ b/test/type_test.ml
@@ -4,11 +4,14 @@ open Test_utils
 
 let%expect_test "let expressions" =
   compile_string "let y = 10;";
-  [%expect {| int y = 10; |}]
+  [%expect {|
+    #include "apcint.h"
+    int y = 10; |}]
 
 let%expect_test "add" =
   compile_string "let x = 2.5; let z = 3.5; x + z;";
   [%expect {|
+    #include "apcint.h"
     float x = 2.5;
     float z = 3.5;
     x+z |}]
@@ -16,23 +19,26 @@ let%expect_test "add" =
 let%expect_test "boolean" =
   compile_string "let x = true; let y = false;";
   [%expect {|
+    #include "apcint.h"
     int x = 1;
     int y = 0; |}]
 
 let%expect_test "type aliases get erased" =
   compile_string "type b = bool; type i = bit<32>; type x = i;";
-  [%expect {| |}]
+  [%expect {| #include "apcint.h" |}]
 
 let%expect_test "Reassign variables" =
   compile_string "let x = true; x := false;";
   [%expect {|
+    #include "apcint.h"
     int x = 1;
     x = 0; |}]
 
 let%expect_test "Reassign arrays" =
   compile_string "func foo(a: bit<32>[10], b: bit<32>[10]) { a[0] := b[0]; }";
   [%expect {|
-    void foo(int a[10], int b[10]) {
+    #include "apcint.h"
+    void foo(int32 a[10], int32 b[10]) {
       /* cap read: b[1*(0)] */
       /* cap write: a[1*(0)] */
       a[1*(0)] = b[1*(0)];
@@ -41,25 +47,28 @@ let%expect_test "Reassign arrays" =
 let%expect_test "Read from array twice" =
   compile_string "func foo(a: bit<32>[10]) { let x = a[1]; let y = a[1];}";
   [%expect {|
-    void foo(int a[10]) {
+    #include "apcint.h"
+    void foo(int32 a[10]) {
       /* cap read: a[1*(1)] */
-      int x = a[1*(1)];
-      int y = a[1*(1)];
+      int32 x = a[1*(1)];
+      int32 y = a[1*(1)];
     } |}]
 
 let%expect_test "Read from array twice with explicit capability" =
   compile_string "func foo(a: bit<32>[10]) { read a[1] as a1; let x = a1; let y = a1;}";
   [%expect {|
-    void foo(int a[10]) {
+    #include "apcint.h"
+    void foo(int32 a[10]) {
       /* cap read: a[1*(1)] */
-      int x = a[1*(1)];
-      int y = a[1*(1)];
+      int32 x = a[1*(1)];
+      int32 y = a[1*(1)];
     } |}]
 
 let%expect_test "Write to an array with explicit capability" =
   compile_string "func foo(a: bit<32>[10]) { write a[1] as a1; a1 := 1;}";
   [%expect {|
-    void foo(int a[10]) {
+    #include "apcint.h"
+    void foo(int32 a[10]) {
       /* cap write: a[1*(1)] */
       a[1*(1)] = 1;
     } |}]

--- a/test/type_test.ml
+++ b/test/type_test.ml
@@ -38,7 +38,7 @@ let%expect_test "Reassign arrays" =
   compile_string "func foo(a: bit<32>[10], b: bit<32>[10]) { a[0] := b[0]; }";
   [%expect {|
     #include "apcint.h"
-    void foo(int32 a[10], int32 b[10]) {
+    void foo(uint32 a[10], uint32 b[10]) {
       /* cap read: b[1*(0)] */
       /* cap write: a[1*(0)] */
       a[1*(0)] = b[1*(0)];
@@ -48,27 +48,27 @@ let%expect_test "Read from array twice" =
   compile_string "func foo(a: bit<32>[10]) { let x = a[1]; let y = a[1];}";
   [%expect {|
     #include "apcint.h"
-    void foo(int32 a[10]) {
+    void foo(uint32 a[10]) {
       /* cap read: a[1*(1)] */
-      int32 x = a[1*(1)];
-      int32 y = a[1*(1)];
+      uint32 x = a[1*(1)];
+      uint32 y = a[1*(1)];
     } |}]
 
 let%expect_test "Read from array twice with explicit capability" =
   compile_string "func foo(a: bit<32>[10]) { read a[1] as a1; let x = a1; let y = a1;}";
   [%expect {|
     #include "apcint.h"
-    void foo(int32 a[10]) {
+    void foo(uint32 a[10]) {
       /* cap read: a[1*(1)] */
-      int32 x = a[1*(1)];
-      int32 y = a[1*(1)];
+      uint32 x = a[1*(1)];
+      uint32 y = a[1*(1)];
     } |}]
 
 let%expect_test "Write to an array with explicit capability" =
   compile_string "func foo(a: bit<32>[10]) { write a[1] as a1; a1 := 1;}";
   [%expect {|
     #include "apcint.h"
-    void foo(int32 a[10]) {
+    void foo(uint32 a[10]) {
       /* cap write: a[1*(1)] */
       a[1*(1)] = 1;
     } |}]


### PR DESCRIPTION
Does this:
- Instead of parsing `int` in type annotations, parses `bit<n>`.
- When there are operations between single-value index types (i.e. index types with trivial static components), the resulting index type has a dynamic component that envelops both of the operands' dynamic ranges.
- The type strings in the error messages for index types now say `bit<n>` when appropriate.

Also updated the test files to have `bit<32>` annotations instead of `int`.

Closed the other PR and just did this in a fresh new branch.

**edit**: now emitted code includes `apcint.h` header and adds number of bits to `int` type annotations.