### PR TITLE
Index overflow fix

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,7 +1,9 @@
 (* Definitions for various ast and type nodes. *)
 
+type offset = Lin of int | Exp of int
+
 (* Type for identifiers. *)
-type id = string
+and id = string
 
 (* A [type_node] is one of the following:
  *   - [TBool]: a boolean type
@@ -29,7 +31,7 @@ and type_node =
   | TMux of id * int
   | TLin of type_node
   | TArray of type_node * (int * int) list
-  | TIndex of (int * int) * (int * int)
+  | TIndex of (int * int) * (int * offset)
   | TFunc of type_node list
 
 and binop =

--- a/src/emit.ml
+++ b/src/emit.ml
@@ -42,13 +42,18 @@ let compute_array_size dims =
 
 let type_str = function
   | TBool -> "int"
-  | TIndex (_, (_, hs)) ->
+  | TIndex (_, (_, hd)) ->
     let bits_st =
-      if hs=1 (* static number, don't annotate *) then ""
-      else Core.Int.floor_log2 hs |> string_of_int in
+      match hd with
+      | Lin 1 -> (* static number, don't annotate *) ""
+      | Exp 0 -> (* static number, don't annotate *) ""
+      | Exp n -> string_of_int n
+      | Lin n -> Core.Int.floor_log2 n |> string_of_int in
     let int_st =
-      if hs=1 then "int"
-      else "uint" in
+      match hd with
+      | Lin 1 -> "int"
+      | Exp 0 -> "int"
+      | _     -> "uint" in
     concat [ int_st; bits_st ]
   | TFloat -> "float"
   | t -> failwith (Printf.sprintf "Cannot emit type %s." (show_type_node t))

--- a/src/error_msg.ml
+++ b/src/error_msg.ml
@@ -7,21 +7,28 @@ exception TypeError of string
  *  - [true] if [d] is (0, 2^n) for some n
     - [false] otherwise *)
 let is_ubit (ld, hd) =
-  ld=0 && hd <> 0 && hd land (hd-1) = 0
+  match (ld, hd) with
+  | 0, Exp _ -> true
+  | _ -> false
+
+let string_of_offset = function
+  | Exp e -> string_of_int e
+  | Lin l -> string_of_int l
 
 (* [pprint_idx s d] is a string representation of the index type
  * [TIndex (s, d)), which is:
  *  - unsigned bit<n> if [s] is (0, 1), and [d] is (0..2^n)
  *  - idx<...> otherwise *)
-let pprint_idx s d =
+let pprint_idx (s:int*int) (d:int*offset) =
   let (ls, hs), (ld, hd) = s, d in
-    if (ls, hs) = (0, 1) && is_ubit d then
-      sprintf "unsigned bit<%s>" @@ string_of_int (Core.Int.floor_log2 hd)
-    else sprintf "idx<%s..%s, %s..%s>"
-      (string_of_int ls)
-      (string_of_int hs)
-      (string_of_int ld)
-      (string_of_int hd)
+    if (ls, hs) = (0, 1) && is_ubit (ld, hd) then
+      sprintf "unsigned bit<%s>" @@ string_of_offset hd
+    else
+      sprintf "idx<%s..%s, %s..%s>"
+        (string_of_int ls)
+        (string_of_int hs)
+        (string_of_int ld)
+        (string_of_offset hd)
 
 let rec string_of_type = function
   | TBool -> "bool"

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -99,7 +99,7 @@ bit_annotation:
   | BIT LT INT GT { $3 }
 
 basic_type:
-  | bit_annotation              { TIndex ((0, 1), (0, Core.Int.pow 2 $1)) }
+  | bit_annotation              { TIndex ((0, 1), (0, Exp $1)) }
   | BOOL_ANNOTATION             { TBool }
   | FLOAT_ANNOTATION            { TFloat }
   | ID                          { TAlias $1 }

--- a/src/type.ml
+++ b/src/type.ml
@@ -163,19 +163,19 @@ and check_assignment id exp ctx =
   let (t, c) = check_expr exp ctx in
   Context.add_binding id t c
 
-and fst_larger (r1:int*offset) (r2:int*offset) =
+and fst_smaller (r1:int*offset) (r2:int*offset) =
   match r1, r2 with
   | (l1, Lin h1), (l2, Lin h2) -> h1-l1 < h2-l2
   | (_, Lin h1),  (_, Exp h2)  -> (Core.Int.floor_log2 h1)<h2
   | (_, Exp h1),  (_, Lin h2)  -> h1<(Core.Int.floor_log2 h2)
   | (_, Exp h1),  (_, Exp h2)  -> h1<h2
 
-(** [check_bitsizes target v] is (). It raises [TypeError] if [target]
- * is represented with less bits than [v]. *)
+(** [check_bitsizes t1 t2] is (). It raises [TypeError] if [t1]
+ * is represented with less bits than [t2]. *)
 and check_bitsizes t1 t2 =
   match t1, t2 with
   | TIndex (_, r1), TIndex (_, r2) ->
-    if fst_larger r1 r2 then
+    if fst_smaller r1 r2 then
       raise @@ TypeError (reassign_bit_violation t1 t2)
   | _ -> ()
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -165,7 +165,7 @@ and check_assignment id exp ctx =
 
 and fst_larger (r1:int*offset) (r2:int*offset) =
   match r1, r2 with
-  | (l1, Lin h1), (l2, Lin h2) -> h1-l1 < l2-h2
+  | (l1, Lin h1), (l2, Lin h2) -> h1-l1 < h2-l2
   | (_, Lin h1),  (_, Exp h2)  -> (Core.Int.floor_log2 h1)<h2
   | (_, Exp h1),  (_, Lin h2)  -> h1<(Core.Int.floor_log2 h2)
   | (_, Exp h1),  (_, Exp h2)  -> h1<h2

--- a/test/should-compile/bignums.sea
+++ b/test/should-compile/bignums.sea
@@ -1,0 +1,7 @@
+type int = bit<64>;
+func madd(a: int[1024 bank(32)], b: int, c: int[1024 bank(32)]) {
+  for (let i = 0..31) {
+    c{0}[i] := a{0}[i] + b;
+    c{1}[i] := a{1}[i] + b;
+  }
+}

--- a/test/test_programs.ml
+++ b/test/test_programs.ml
@@ -130,6 +130,23 @@ let%expect_test "should-compile/vsadd_nrl_typedefs.sea" =
       }
     } |}]
 
+let%expect_test "should-compile/bignums.sea" =
+  compile "should-compile/bignums.sea";
+  [%expect {|
+    #include "apcint.h"
+    void madd(uint64 a[1024], uint64 b, uint64 c[1024]) {
+      #pragma HLS ARRAY_PARTITION variable=a factor=32
+      #pragma HLS ARRAY_PARTITION variable=c factor=32
+      for (int i = 0; i <= 31; i += 1) {
+        /* cap read: a[0 + 32*(i)] */
+        /* cap write: c[0 + 32*(i)] */
+        c[0 + 32*(i)] = a[0 + 32*(i)]+b;
+        /* cap read: a[1 + 32*(i)] */
+        /* cap write: c[1 + 32*(i)] */
+        c[1 + 32*(i)] = a[1 + 32*(i)]+b;
+      }
+    } |}]
+
 (** TODO(rachit): These tests need + on idx types to be implemented
 
 let%expect_test "should-compile/logical_access.sea" =


### PR DESCRIPTION
This addresses issue #37. Instead of having the range endpoint of the dynamic component be a potentially enormous number, it's something of type `offset`, which is either a normal number, or an exponential number (`Lin of int | Exp of int`).