### PR TITLE
scala: Use a simpler command-line syntax

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,26 +1,26 @@
 package fuselang
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.Files
+import java.io.File
 
 object Main {
-  case class Config(filename: String)
+  case class Config(srcfile: File)
 
   val parser = new scopt.OptionParser[Config]("fuse"){
 
     head("fuse", "0.0.1")
 
-    opt[String]('f', "srcFile")
+    arg[File]("<srcfile>")
       .required()
-      .valueName("<file>")
-      .action((x, c) => c.copy(filename = x))
-      .text("srcFile containing fuse source code")
+      .action((x, c) => c.copy(srcfile = x))
+      .text("source code file")
   }
 
   def main(args: Array[String]) = {
 
-    parser.parse(args, Config("")) match {
+    parser.parse(args, Config(null)) match {
       case Some(c) => {
-        val prog = new String(Files.readAllBytes(Paths.get(c.filename)))
+        val prog = new String(Files.readAllBytes(c.srcfile.toPath()))
         println(Compiler.compileString(prog))
       }
       case None => {


### PR DESCRIPTION
This doesn't require `-f` to pass the file to parse; it's now a positional argument, so you type `./fuse file.sea` to compile. I also used scopt's `File` option type, which does some path-specific stuff.