### PR TITLE
Function support

### DIFF
--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -61,7 +61,7 @@ object Errors {
     s"Variable $id not defined.", Some(id.pos))
 
   case class AlreadyBound(id: Id) extends TypeError(
-    s"Variable $id already bound in scope at ${id}.", Some(id.pos))
+    s"Variable $id already bound in scope", Some(id.pos))
 
   // Reduction errors
   case class ReductionInvalidRHS(p: Position, rop: ROp, tl: Type, tr: Type) extends TypeError(

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -34,6 +34,7 @@ object Syntax {
     }
 
     override def toString = this match {
+      case _: TVoid => "void"
       case _: TBool => "bool"
       case _: TFloat => "float"
       case TSizedInt(l) => s"int$l"
@@ -41,13 +42,16 @@ object Syntax {
       case TArray(t, dims) =>
         s"$t" + dims.foldLeft("")({ case (acc, (d, b)) => s"$acc[$d bank $b]" })
       case TIndex(s, d) => s"idx($s, $d)"
+      case TFun(args) => args.foldLeft("")({ case (acc, t) => s"$acc$t -> "}) + "void"
     }
   }
   // Use case class instead of case object to get unique positions
+  case class TVoid() extends Type
   case class TBool() extends Type
   case class TFloat() extends Type
   case class TSizedInt(len: Int) extends Type
   case class TStaticInt(v: Int) extends Type
+  case class TFun(args: List[Type]) extends Type
   case class TArray(typ: Type, dims: List[(Int, Int)]) extends Type
   case class TIndex(static: (Int, Int), dynamic: (Int, Int)) extends Type
 
@@ -119,6 +123,7 @@ object Syntax {
   case class EBool(v: Boolean) extends Expr
   case class EBinop(op: BOp, e1: Expr, e2: Expr) extends Expr
   case class EAA(id: Id, idxs: List[Expr]) extends Expr
+  case class EApp(func: Id, args: List[Expr]) extends Expr
   case class EVar(id: Id) extends Expr
 
   case class CRange(iter: Id, s: Int, e: Int, u: Int) extends Positional {
@@ -161,6 +166,7 @@ object Syntax {
   case object CEmpty extends Command
 
   case class Decl(id: Id, typ: Type) extends Positional
+  case class FDef(id: Id, args: List[Decl], body: Command) extends Positional
 
-  case class Prog(decls: List[Decl], cmd: Command) extends Positional
+  case class Prog(fdefs: List[FDef], decls: List[Decl], cmd: Command) extends Positional
 }

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -145,8 +145,8 @@ object TypeChecker {
         // All functions return `void`.
         TVoid() -> args.zip(argTypes).foldLeft(env)({ case (e, (arg, expectedTyp)) => {
           val (typ, e1) = checkE(arg)(e, rres);
-          if (typ != expectedTyp) {
-            throw UnexpectedType(arg.pos, "parameter", expectedTyp.toString, typ)
+          if (typ :< expectedTyp == false) {
+            throw UnexpectedSubtype(arg.pos, "parameter", expectedTyp, typ)
           }
           // If an array id is used as a parameter, consume it completely.
           // This works correctly with capabilties.

--- a/src/main/scala/TypeEnv.scala
+++ b/src/main/scala/TypeEnv.scala
@@ -85,7 +85,7 @@ object TypeEnv {
         }
         case None => throw UnknownDim(id, dim)
       }
-      case _ => ??? // Cannot happen
+      case t => throw Impossible(s"consumeDim called on non-array type $t")
     }
 
     def consumeAll = typ match {

--- a/src/main/scala/TypeEnv.scala
+++ b/src/main/scala/TypeEnv.scala
@@ -87,6 +87,14 @@ object TypeEnv {
       }
       case _ => ??? // Cannot happen
     }
+
+    def consumeAll = typ match {
+      case TArray(_, dims) => dims.foldLeft(this)({
+        case (info, (dim, bank)) => info.consumeDim(dim, bank)
+      })
+      case _ => throw Impossible("consumeAll called on non-array")
+    }
+
     override def toString = s"{$typ, $avBanks, $conBanks}"
   }
   object Info {

--- a/src/main/scala/TypeEnv.scala
+++ b/src/main/scala/TypeEnv.scala
@@ -89,8 +89,8 @@ object TypeEnv {
     }
 
     def consumeAll = typ match {
-      case TArray(_, dims) => dims.foldLeft(this)({
-        case (info, (dim, bank)) => info.consumeDim(dim, bank)
+      case TArray(_, dims) => dims.zipWithIndex.foldLeft(this)({
+        case (info, ((_, bank), dim)) => info.consumeDim(dim, bank)
       })
       case _ => throw Impossible("consumeAll called on non-array")
     }

--- a/src/test/resources/should-compile/function.se
+++ b/src/test/resources/should-compile/function.se
@@ -1,0 +1,6 @@
+def bar(a: bit<10>[10 bank 5]) {
+  a[1] := 10;
+}
+
+decl x: bit<10>[10 bank 5];
+bar(x);

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -98,5 +98,17 @@ class ParsingPositive extends org.scalatest.FunSuite {
       """ )
   }
 
+  test("functions") {
+    println(parseAst("""
+      def foo(a: bit<32>) {}
+      """ ))
+
+    println(parseAst("""
+      def foo(a: bit<32>[10 bank 5], b: bool) {
+        bar(1, 2, 3)
+      }
+      """ ))
+  }
+
 }
 

--- a/src/test/scala/TypeNegative.scala
+++ b/src/test/scala/TypeNegative.scala
@@ -350,6 +350,64 @@ class SimpleTypeNegative extends FunSpec {
 
   }
 
+  describe("Functions") {
+    it("cannot have same name for multiple params") {
+      assertThrows[AlreadyBound] {
+        typeCheck("""
+          def foo(a: bool, a: bit<10>) {}
+          """ )
+      }
+    }
+
+    it("cannot be used before defintion") {
+      assertThrows[UnboundVar] {
+        typeCheck("""
+          def bar(a: bool) { foo(a) }
+          def foo(a: bool) { foo(a) }
+          """ )
+      }
+    }
+
+    it("do no allow recursion") {
+      assertThrows[UnboundVar] {
+        typeCheck("""
+          def bar(a: bool) { bar(a) }
+          """ )
+      }
+    }
+  }
+
+  describe("Function applications") {
+    it("require the correct types") {
+      assertThrows[UnexpectedSubtype] {
+        typeCheck("""
+          def bar(a: bool) { }
+          bar(1)
+          """ )
+      }
+    }
+
+    it("completely consume array parameters") {
+      assertThrows[AlreadyConsumed] {
+        typeCheck("""
+          def bar(a: bit<10>[10 bank 5]) { }
+          decl x: bit<10>[10 bank 5];
+          bar(x);
+          x[1]
+          """ )
+      }
+    }
+
+    it("do not return values") {
+      assertThrows[BinopError] {
+        typeCheck("""
+          def bar(a: bit<10>) { a }
+          1 + bar(10)
+          """ )
+      }
+    }
+  }
+
 }
 
 class FileTypeNegative extends FunSuite {


### PR DESCRIPTION
Fixes #54 #62.

- Program structure is now a list of function defs followed by a list of decls, followed by top level commands.
- Applications consume array expressions completely
- Functions cannot return values (will potentially fix this in the future) and have return type `void`.