### PR TITLE
Implementation of shrink views

### DIFF
--- a/examples/errors/multiwrite.sea
+++ b/examples/errors/multiwrite.sea
@@ -1,9 +1,0 @@
-func mmul(a: float[3][3 bank(3)], b: float[3][3 bank(3)], c: float[3]) {
-
-  for (let i = 0..3) unroll 1 {
-    for (let j = 0..3) unroll 3 {
-      c[i] := a[i][j] + b[i][j];
-    }
-  }
-
-}

--- a/src/main/scala/CodeGenHelpers.scala
+++ b/src/main/scala/CodeGenHelpers.scala
@@ -1,0 +1,25 @@
+package fuselang
+
+object CodeGenHelpers {
+  import Syntax._
+
+  implicit class RichExpr(e1: Expr) {
+    def +(e2: Expr) =
+      binop(OpAdd(), e1, e2)
+
+    def *(e2: Expr) =
+      binop(OpMul(), e1, e2)
+  }
+
+  // Simple peephole optimization to turn: 1 * x => x, 0 + x => x, 0 * x => 0
+  def binop(op: BOp, l: Expr, r: Expr) = (op, l, r) match {
+    case (OpMul(), EInt(1), r) => r
+    case (OpMul(), l, EInt(1)) => l
+    case (OpMul(), EInt(0), _) => EInt(0)
+    case (OpMul(), _, EInt(0)) => EInt(0)
+    case (OpAdd(), l, EInt(0)) => l
+    case (OpAdd(), EInt(0), r) => r
+    case _ => EBinop(op, l, r)
+  }
+
+}

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -1,15 +1,23 @@
 package fuselang
 
 import scala.util.{Try, Success, Failure}
+import Utils._
 
 object Compiler {
 
-  def compileString(prog: String, c: Utils.Config) = Try {
+  def compileStringWithError(prog: String, c: Config = emptyConf ) = {
     val ast = FuseParser.parse(prog)
     TypeChecker.typeCheck(ast)
-    Emit.emitProg(ast, c)
+    val rast = RewriteView.rewriteProg(ast)
+    Emit.emitProg(rast, c)
+  }
+
+  def compileString(prog: String, c: Utils.Config) = Try {
+    compileStringWithError(prog, c)
   } match {
     case Success(out) => out
+    case Failure(f: Errors.TypeError) =>
+      "[" + Console.RED + "Type error" + Console.RESET + "] " + f.getMessage
     case Failure(f: RuntimeException) =>
       "[" + Console.RED + "Error" + Console.RESET + "] " + f.getMessage
     case Failure(f) => throw f

--- a/src/main/scala/Emit.scala
+++ b/src/main/scala/Emit.scala
@@ -92,6 +92,7 @@ private class Emit extends PrettyPrinter {
     case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi
     case CExpr(e) => e <> semi
     case CEmpty => ""
+    case _:CView => throw Impossible("Views should not exist during codegen.")
   }
 
   def withArrayType(id: Id) = id.typ match {

--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -46,7 +46,7 @@ object Errors {
     "Already written to this expression in this context.", Some(e.pos))
 
   case class InsufficientResourcesInUnrollContext(exp: Int, ac: Int, expr: Expr)
-    extends TypeError(s"Array access implies $ac safe copies are possible, but implied requirement $ac copies from the surrounding unroll contexts.", Some(expr.pos))
+    extends TypeError(s"Array access implies $ac safe writes are possible, but surrounding context requires $exp copies.", Some(expr.pos))
 
   // Subtyping error
   case class NoJoin(t1: Type, t2: Type) extends TypeError(

--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -67,12 +67,20 @@ object Errors {
   case class ReductionInvalidRHS(p: Position, rop: ROp, tl: Type, tr: Type) extends TypeError(
     s"Unexpected type on right hand side of $rop. Expected: $tl[N bank N], received: $tr", Some(p))
 
+  // View errors
+  case class InvalidShrinkWidth(pos: Position, bf: Int, width: Int) extends TypeError(
+    s"Invalid width for shrink view. Expected factor of $bf (banking factor), received: $width", Some(pos))
+  case class ViewInsideUnroll(pos: Position, vt: ViewType, arrId: Id) extends TypeError(
+    s"Cannot create $vt view for $arrId inside an unrolled context.", Some(pos))
+
   // Parsing errors
   case class ParserError(msg: String) extends RuntimeException(msg)
 
   // Malformed AST Errors
   case class UnexpectedLVal(e: Expr, construct: String) extends RuntimeException(
     withPos(s"Expected L-value in $construct.", Some(e.pos)))
+  case class MalformedShrink(vt: Shrink, w: Int, step: Int) extends RuntimeException(
+    withPos(s"shrink view expects step size == width. Received $step (step), $w (width)", Some(vt.pos)))
 
   // Used when a branch should be impossible at runtime.
   case class Impossible(msg: String) extends RuntimeException(s"Impossible: $msg")

--- a/src/main/scala/RewriteView.scala
+++ b/src/main/scala/RewriteView.scala
@@ -1,0 +1,109 @@
+package fuselang
+
+/**
+ * AST pass to rewrite views into simple array accesses. Should be used after
+ * type checking.
+ *
+ * For `shrink` views, we rewrite them as:
+ *
+ * view v_a = shrink a[4 * i : 4];
+ * v_a[k];
+ * ==>
+ * ; // remove the view decl
+ * a[4*i + k]
+ *
+ * If `a` itself is a view, we keep rewriting it until we reach a true array.
+ */
+object RewriteView {
+  import Syntax._
+  import CodeGenHelpers._
+
+	// We can use a flat environment because the type checker makes sure things
+  // in the right scope.
+  type T = Map[Id, List[Expr] => Expr]
+
+  def foldExprs(es: List[Expr])(implicit env: T): (List[Expr], T) =
+      es.foldLeft((List[Expr](), env))({
+        case ((idxsn, env), e) => {
+          val (e1, env1) = rewriteExpr(e)(env)
+          (e1 :: idxsn, env1)
+        }
+      })
+
+  def rewriteExpr(e: Expr)(implicit env: T): (Expr, T) = e match {
+    case EVar(_) | EInt(_) | EFloat(_) | EBool(_) => e -> env
+    case eb@EBinop(_, e1, e2) => {
+      val (e1n, env1) = rewriteExpr(e1)
+      val (e2n, env2) = rewriteExpr(e2)(env1)
+      eb.copy(e1 = e1n, e2 = e2n) -> env2
+    }
+    case eaa@EAA(arrId, idxs) => {
+      val (idxsn, env1) = foldExprs(idxs)
+      // If the array id is a view array rewrite it and recur
+      if (env.contains(arrId)) {
+        rewriteExpr(env(arrId)(idxsn))
+      } else {
+        eaa.copy(idxs = idxsn) -> env1
+      }
+    }
+    case app@EApp(_, args) => {
+      val (argsn, env1) = foldExprs(args)
+      app.copy(args = argsn) -> env1
+    }
+  }
+
+  def rewriteCommand(c: Command)(implicit env: T): (Command, T) = c match {
+    case CPar(c1, c2) => {
+      val (c1n, env1) = rewriteCommand(c1)
+      val (c2n, env2) = rewriteCommand(c2)(env1)
+      CPar(c1n, c2n) -> env2
+    }
+    case CSeq(c1, c2) => {
+      val (c1n, env1) = rewriteCommand(c1)
+      val (c2n, env2) = rewriteCommand(c2)(env1)
+      CSeq(c1n, c2n) -> env2
+    }
+    case l@CLet(_, _, e) => {
+      val (en, env1) = rewriteExpr(e)
+      l.copy(e = en) -> env1
+    }
+    case CView(id, Shrink(arrId, dims)) => {
+      val f = (es: List[Expr]) => EAA(arrId, es.zip(dims).map({
+        case (e, (idx, _, s)) => e + (idx * EInt(s))
+      }))
+      (CEmpty, env + (id -> f))
+    }
+    case CIf(e1, c2) => {
+      val (e1n, env1) = rewriteExpr(e1)
+      val (c2n, env2) = rewriteCommand(c2)(env1)
+      CIf(e1n, c2n) -> env2
+    }
+    case cf@CFor(_, c1, c2) => {
+      val (c1n, e1) = rewriteCommand(c1)
+      val (c2n, e2) = rewriteCommand(c2)(e1)
+      cf.copy(par = c1n, combine = c2n) -> e2
+    }
+    case CUpdate(e1, e2) => {
+      val (e1n, env1) = rewriteExpr(e1)
+      val (e2n, env2) = rewriteExpr(e2)(env1)
+      CUpdate(e1n, e2n) -> env2
+    }
+    case cr@CReduce(_, e1, e2) => {
+      val (e1n, env1) = rewriteExpr(e1)
+      val (e2n, env2) = rewriteExpr(e2)(env1)
+      cr.copy(lhs = e1n, rhs = e2n) -> env2
+    }
+    case CExpr(exp) => {
+      val (e1n, env1) = rewriteExpr(exp)
+      CExpr(e1n) -> env1
+    }
+    case CEmpty => c -> env
+  }
+
+  def rewriteProg(p: Prog): Prog = {
+    val emptyEnv = Map[Id, List[Expr] => Expr]()
+    val fs = p.fdefs.map(fdef => fdef.copy(body = rewriteCommand(fdef.body)(emptyEnv)._1))
+    val cmdn = rewriteCommand(p.cmd)(emptyEnv)._1
+    p.copy(fdefs = fs, cmd = cmdn)
+  }
+}

--- a/src/main/scala/RewriteView.scala
+++ b/src/main/scala/RewriteView.scala
@@ -18,7 +18,7 @@ object RewriteView {
   import Syntax._
   import CodeGenHelpers._
 
-	// We can use a flat environment because the type checker makes sure things
+  // We can use a flat environment because the type checker makes sure things
   // in the right scope.
   type T = Map[Id, List[Expr] => Expr]
 

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -150,10 +150,21 @@ object Syntax {
   case class RSub() extends ROp
   case class RDiv() extends ROp
 
+  sealed trait ViewType extends Positional
+  case class Shrink(arrId: Id, dims: List[(Expr,Int,Int)]) extends ViewType {
+    dims.forall({ case (_, w, s) => {
+      if (w != s) {
+        throw MalformedShrink(this, w, s)
+      }
+      true
+    }})
+  }
+
   sealed trait Command extends Positional
   case class CPar(c1: Command, c2: Command) extends Command
   case class CSeq(c1: Command, c2: Command) extends Command
   case class CLet(id: Id, var typ: Option[Type], e: Expr) extends Command
+  case class CView(id: Id, kind: ViewType) extends Command
   case class CIf(cond: Expr, cons: Command) extends Command
   case class CFor(range: CRange, par: Command, combine: Command) extends Command
   case class CUpdate(lhs: Expr, rhs: Expr) extends Command {

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -229,7 +229,9 @@ object TypeChecker {
       }
     }
     case CView(id, k@Shrink(arrId, vdims)) => env(arrId).typ match {
-      case TArray(t, dims) => {
+      case arrTyp@TArray(t, dims) => {
+        // Annotate arrId with type
+        arrId.typ = Some(arrTyp)
         // Cannot create shrink views in unrolled contexts
         if (rres != 1) {
           throw ViewInsideUnroll(cmd.pos, k, arrId)

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -2,6 +2,8 @@ package fuselang
 
 object Utils {
 
+  val emptyConf = Config(null)
+
   case class Config(
     srcFile: java.io.File, // Required: Name of the source file
     kernelName: String = "kernel" // Name of the kernel to emit

--- a/src/test/resources/should-compile/shrink-view-simple.se
+++ b/src/test/resources/should-compile/shrink-view-simple.se
@@ -1,0 +1,7 @@
+decl a: bit<10>[16 bank 8];
+decl b: bit<10>[8];
+
+for (let i = 0..12) {
+  view v_a = shrink a[2*i:2];
+  b[i] := v_a[0] + 2*v_a[1]
+}

--- a/src/test/resources/should-fail/multiwrite.se
+++ b/src/test/resources/should-fail/multiwrite.se
@@ -1,0 +1,9 @@
+decl a: float[3][3 bank 3];
+decl b: float[3][3 bank 3];
+decl c: float[3];
+
+for (let i = 0..3) {
+  for (let j = 0..3) unroll 3 {
+    c[i] := a[i][j] + b[i][j];
+  }
+}

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -1,6 +1,6 @@
 package fuselang
 
-import Utils._
+import TestUtils._
 
 class ParsingPositive extends org.scalatest.FunSuite {
   test("atoms parseAst") {
@@ -111,9 +111,9 @@ class ParsingPositive extends org.scalatest.FunSuite {
   }
 
   test("views") {
-    println(parseAst("""
+    parseAst("""
       view v_a = shrink a[4 * i : 4]
-      """ ))
+      """ )
   }
 
 }

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -99,14 +99,20 @@ class ParsingPositive extends org.scalatest.FunSuite {
   }
 
   test("functions") {
-    println(parseAst("""
+    parseAst("""
       def foo(a: bit<32>) {}
-      """ ))
+      """ )
 
-    println(parseAst("""
+    parseAst("""
       def foo(a: bit<32>[10 bank 5], b: bool) {
         bar(1, 2, 3)
       }
+      """ )
+  }
+
+  test("views") {
+    println(parseAst("""
+      view v_a = shrink a[4 * i : 4]
       """ ))
   }
 

--- a/src/test/scala/TestUtils.scala
+++ b/src/test/scala/TestUtils.scala
@@ -1,6 +1,6 @@
 package fuselang
 
-object Utils {
+object TestUtils {
 
   import scala.language.implicitConversions
 

--- a/src/test/scala/TypeNegative.scala
+++ b/src/test/scala/TypeNegative.scala
@@ -1,6 +1,6 @@
 package fuselang
 
-import Utils._
+import TestUtils._
 import Errors._
 import org.scalatest.{FunSpec, FunSuite}
 
@@ -525,7 +525,7 @@ class FileTypeNegative extends FunSuite {
     test(file.toString) {
       val prog = new String(Files.readAllBytes(file))
       assertThrows[TypeError] {
-        typeCheck(prog)
+        Compiler.compileStringWithError(prog)
       }
     }
   }

--- a/src/test/scala/TypePositive.scala
+++ b/src/test/scala/TypePositive.scala
@@ -1,6 +1,6 @@
 package fuselang
 
-import Utils._
+import TestUtils._
 import Syntax._
 import org.scalatest.FunSuite
 
@@ -181,7 +181,7 @@ class FileTypePositive extends FunSuite {
   for (file <- Files.newDirectoryStream(shouldCompile).asScala) {
     test(file.toString) {
       val prog = new String(Files.readAllBytes(file))
-      typeCheck(prog)
+      Compiler.compileStringWithError(prog)
     }
   }
 


### PR DESCRIPTION
This PR implements `shrink` views and partially addresses #57.

Overview:
- Shrink view can be defined using `view v = a[0:w]` or `view v = a[n * i:w]`.
  - In the second case `n * off`, `n` is the step size and **must be equal** to `w`. This is to make sure that programmer does trip with the stepping semantics of `shrink` views.
- Shrink views cannot be defined in an unroll context. This restriction can potentially be removed in the future.
- For an array `a: t[len bank b]...`, the view must have the same number of dimensions, the same type `t` and banking factor `b'` such that `b % b' == 0`. This also means that `shrink` views are always fully banked.
- A `view v = <view_type> arr...` expression completely consumes `arr` from the current context.

**TODO**
- [X] Write a code gen phase.