### PR TITLE
Implement else branches

### DIFF
--- a/src/main/scala/Emit.scala
+++ b/src/main/scala/Emit.scala
@@ -73,7 +73,8 @@ private class Emit extends PrettyPrinter {
     case CPar(c1, c2) => c1 <@> c2
     case CSeq(c1, c2) => c1 <@> text("//---") <@> c2
     case CLet(id, typ, e) => typ.get <+> value(id) <+> equal <+> e <> semi
-    case CIf(cond, cons) => "if" <> parens(cond) <> scope (cons)
+    case CIf(cond, cons, alt) =>
+      "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
     case CFor(range, par, combine) =>
       "for" <> parens {
         "int" <+> range.iter <+> "=" <+> value(range.s) <> semi <+>

--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -2,6 +2,7 @@ package fuselang
 
 object Errors {
   import Syntax._
+  import TypeEnv.Capability
   import scala.util.parsing.input.Position
 
   def withPos(s: String, pos: Option[Position]) =
@@ -39,7 +40,7 @@ object Errors {
     s"Bank $bank in dimension $dim of $id already consumed.", None)
 
   // Invalid Capability error
-  case class InvalidCap(expr: Expr, exp: String, actual: String) extends TypeError(
+  case class InvalidCap(expr: Expr, exp: Capability, actual: Capability) extends TypeError(
     s"This expression requires $exp capability, but previous usage inferred $actual capability.", Some(expr.pos))
 
   case class AlreadyWrite(e: Expr) extends TypeError(

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -165,8 +165,8 @@ private class FuseParser extends RegexParsers with PackratParsers {
 
   // If
   lazy val conditional: P[Command] = positioned {
-    "if" ~> parens(expr) ~ block ~ "else" ~ block.?  ^^ {
-      case cond ~ cons ~ _ ~ alt => CIf(cond, cons, if (alt.isDefined) alt.get else CEmpty )
+    "if" ~> parens(expr) ~ block ~ ("else" ~> block).?  ^^ {
+      case cond ~ cons ~ alt => CIf(cond, cons, if (alt.isDefined) alt.get else CEmpty )
     }
   }
 

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -163,14 +163,21 @@ private class FuseParser extends RegexParsers with PackratParsers {
     }
   }
 
+  // If
+  lazy val conditional: P[Command] = positioned {
+    "if" ~> parens(expr) ~ block ~ "else" ~ block.?  ^^ {
+      case cond ~ cons ~ _ ~ alt => CIf(cond, cons, if (alt.isDefined) alt.get else CEmpty )
+    }
+  }
+
   // Other commands
   lazy val acmd: P[Command] = positioned {
     block |
     cfor |
+    conditional |
     "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) } |
     "let" ~> iden ~ (":" ~> typ).? ~ ("=" ~> expr) ^^ { case id ~ t ~ exp => CLet(id, t, exp) } |
     "view" ~> iden ~ "=" ~ view ^^ { case arrId ~ _ ~ vt => CView(arrId, vt) } |
-    "if" ~> parens(expr) ~ block  ^^ { case cond ~ cons => CIf(cond, cons) } |
     expr ~ ":=" ~ expr ^^ { case l ~ _ ~ r => CUpdate(l, r) } |
     expr ~ rop ~ expr ^^ { case l ~ rop ~ r => CReduce(rop, l, r) } |
     expr ^^ { case e => CExpr(e) }

--- a/src/main/scala/RewriteView.scala
+++ b/src/main/scala/RewriteView.scala
@@ -73,10 +73,11 @@ object RewriteView {
       }))
       (CEmpty, env + (id -> f))
     }
-    case CIf(e1, c2) => {
+    case CIf(e1, c1, c2) => {
       val (e1n, env1) = rewriteExpr(e1)
-      val (c2n, env2) = rewriteCommand(c2)(env1)
-      CIf(e1n, c2n) -> env2
+      val (c1n, env2) = rewriteCommand(c1)(env1)
+      val (c2n, env3) = rewriteCommand(c2)(env2)
+      CIf(e1n, c1n, c2n) -> env3
     }
     case cf@CFor(_, c1, c2) => {
       val (c1n, e1) = rewriteCommand(c1)

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -156,11 +156,10 @@ object Syntax {
 
   sealed trait ViewType extends Positional
   case class Shrink(arrId: Id, dims: List[(Expr,Int,Int)]) extends ViewType {
-    dims.forall({ case (_, w, s) => {
+    dims.foreach({ case (_, w, s) => {
       if (w != s) {
         throw MalformedShrink(this, w, s)
       }
-      true
     }})
   }
 

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -139,7 +139,6 @@ object Syntax {
         TIndex((0, u), (s/u, e/u))
       }
     }
-
   }
 
   sealed trait ROp extends Positional {
@@ -170,7 +169,7 @@ object Syntax {
   case class CSeq(c1: Command, c2: Command) extends Command
   case class CLet(id: Id, var typ: Option[Type], e: Expr) extends Command
   case class CView(id: Id, kind: ViewType) extends Command
-  case class CIf(cond: Expr, cons: Command) extends Command
+  case class CIf(cond: Expr, cons: Command, alt: Command) extends Command
   case class CFor(range: CRange, par: Command, combine: Command) extends Command
   case class CWhile(cond: Expr, body: Command) extends Command
   case class CUpdate(lhs: Expr, rhs: Expr) extends Command {

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -81,7 +81,7 @@ object TypeChecker {
         // Capability check
         env.getCap(e) match {
           case Some(Write) => throw AlreadyWrite(e)
-          case Some(Read) => throw InvalidCap(e, Write.toString, Read.toString)
+          case Some(Read) => throw InvalidCap(e, Write, Read)
           case None => {
             val (e1, bres) = consumeBanks(id, idxs, dims)
             if (bres != rreq)
@@ -170,7 +170,7 @@ object TypeChecker {
         // Check capabilities
         env.getCap(expr) match {
           case Some(Write) =>
-            throw InvalidCap(expr, Read.toString, Write.toString)
+            throw InvalidCap(expr, Read, Write)
           case Some(Read) => typ -> env
           case None => {
             val e1 = consumeBanks(id, idxs, dims)._1

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -182,7 +182,7 @@ object TypeChecker {
 
   private def checkC(cmd: Command)(implicit env: Env, rres: ReqResources): Env = cmd match {
     case CPar(c1, c2) => checkC(c2)(checkC(c1), rres)
-    case CIf(cond, cons) => {
+    case CIf(cond, cons, _) => {
       val (cTyp, e1) = checkE(cond)(env.addScope, rres)
       if (cTyp != TBool()) {
         throw UnexpectedType(cond.pos, "if condition", TBool().toString, cTyp)

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -189,15 +189,8 @@ object TypeChecker {
       if (cTyp != TBool()) {
         throw UnexpectedType(cond.pos, "if condition", TBool().toString, cTyp)
       } else {
-        val (e2, _, caps1) = checkC(cons)(e1, rres).endScope
-        val (e3, _, caps2) = checkC(alt)(e1, rres).endScope
-        // Capabilities for common expressions must be the same
-        (caps1.keys.toSet intersect caps2.keys.toSet).foreach({ case expr => {
-          val (cCap, aCap) = (caps1(expr), caps2(expr))
-          if (cCap != aCap) {
-            throw InvalidCap(expr, cCap, aCap)
-          }
-        }})
+        val (e2, _, _) = checkC(cons)(e1, rres).endScope
+        val (e3, _, _) = checkC(alt)(e1, rres).endScope
         e2 merge e3
       }
     }

--- a/src/main/scala/TypeEnv.scala
+++ b/src/main/scala/TypeEnv.scala
@@ -4,54 +4,84 @@ import Syntax._
 import Errors._
 
 object TypeEnv {
-
-  type Stack[T] = List[T]
-  type Scope = Map[Id, Info]
-  type CapScope = Map[Expr, Capability]
-
-  // Product of all unroll factors enclosing the current context.
-  type ReqResources = Int
-
-  // capabilities for read/write
+  // Capabilities for read/write
   sealed trait Capability
   case object Read extends Capability
   case object Write extends Capability
 
-  val emptyEnv: Env = Env(List(Map()), List(Map()))
+  val emptyEnv: Environment = Env(List(Map[Id, Info]()), List(Map[Expr, Capability]()))
 
-  case class Env(e: Stack[Scope], caps: Stack[CapScope]) {
-    def addScope = Env(Map[Id, Info]() :: e, Map[Expr, Capability]() :: caps)
-    def endScope = (Env(e.tail, caps.tail), e.head, caps.head)
-    def apply(id: Id): Info = find(e, id) match {
-      case Some(info) => info
-      case None => throw UnboundVar(id)
-    }
+  // Product of all unroll factors enclosing the current context.
+  type ReqResources = Int
 
-    def getCap(expr: Expr): Option[Capability] =
-      caps.find(c => c.get(expr).isDefined).map(c => c(expr))
+  trait Environment {
 
-    def addCap(expr: Expr, cap: Capability) =
-      Env(e, caps.head + (expr -> cap) :: caps.tail)
+    // A Scope in the environment
+    type Scope[K, V] = Map[K, V]
 
-    private def find(e: Stack[Scope], id: Id): Option[Info] =
-      e.find(m => m.get(id).isDefined) match {
-        case None => None
-        case Some(map) => Some(map(id))
-      }
+    /**
+     * Methods to manipulate the scopes with the environment.
+     * INVARIANT: There is at least one scope in the environment.
+     */
+    /** Create a new binding scope in the environment. */
+    def addScope: Environment
+    /**
+     *  Remove the topmost scope from the environment.
+     *  @returns A new environment without the topmost scope, A Scope containing
+     *           all bindings in the topmost scope.
+     */
+    def endScope: (Environment, Scope[Id, Info])
 
-    def add(bind: (Id, Info)) = find(e, bind._1) match {
-      case Some(_) => throw AlreadyBound(bind._1)
-      case None => Env(e.head + bind :: e.tail, caps)
-    }
-    def update(bind: (Id, Info)) = find(e, bind._1) match {
-      case None => throw UnboundVar(bind._1)
-      case Some(_) => {
-        val scope = e.indexWhere(m => m.get(bind._1).isDefined)
-        Env(e.updated(scope, e(scope) + bind), caps)
-      }
-    }
-    def ++(binds: Scope): Env =
-      binds.foldLeft(this)({ case (e, b) => e.add(b) })
+    /**
+     * Type binding manipulation
+     */
+    /**
+     * Use application syntax to get a type bindings for [[id]].
+     * @param id The id whose binding is needed
+     * @returns Information associated with the id
+     * @throws [[UnboundVar]] If there is no bindings for id
+     */
+    def apply(id: Id): Info
+
+    /**
+     * Add a new type binding in the current scope.
+     * @param bind The binding to be added to the environment.
+     * @return A new environment which contains the mapping.
+     * @throws [[AlreadyBound]] if a bindings for Id already exists.
+     */
+    def add(bind: (Id, Info)): Environment
+
+    /**
+     * Update bindings associated with Id. Method traverses the entire scope chain.
+     * @param bind The new binding for Id.
+     * @return A new environment where Id is bound to this Type.
+     * @throw [[UnboundVar]] If the Id doesn't already have a binding
+     */
+    def update(bind: (Id, Info)): Environment
+
+    /**
+     * Create a new Environment with all the bindings in [[binds]] added to the
+     * current scope.
+     * @param binds A scope with bindings to be added to the environment.
+     * @returns A new environment with all the bindings in the environment.
+     */
+    def ++(binds: Scope[Id, Info]): Environment
+
+    /**
+     * Capability manipulation
+     */
+    /** Get the capability associated with [[e]].
+     *  @param e The Expr to get the capability for.
+     *  @returns The Capability associated with e. Returns None if no association is found.
+     */
+    def getCap(e: Expr): Option[Capability]
+    /**
+     * Associate the capabilitie [[cap]] to the expressions [[e]].
+     * @param e The param with which the capability is associated
+     * @param cap The capability the expression has.
+     * @return A new environment which contains the capability mapping.
+     */
+    def addCap(e: Expr, cap: Capability): Environment
 
   }
 
@@ -60,6 +90,7 @@ object TypeEnv {
     typ: Type,
     avBanks: Map[Int, Set[Int]],
     conBanks: Map[Int, Set[Int]]) {
+
     def consumeBank(dim: Int, bank: Int): Info = avBanks.contains(dim) match {
       case true => if (avBanks(dim).contains(bank)) {
         Info(
@@ -87,7 +118,6 @@ object TypeEnv {
       }
       case t => throw Impossible(s"consumeDim called on non-array type $t")
     }
-
     def consumeAll = typ match {
       case TArray(_, dims) => dims.zipWithIndex.foldLeft(this)({
         case (info, ((_, bank), dim)) => info.consumeDim(dim, bank)
@@ -97,6 +127,8 @@ object TypeEnv {
 
     override def toString = s"{$typ, $avBanks, $conBanks}"
   }
+
+  // Companion object to allow for easier construction of Info.
   object Info {
     def apply(id: Id, typ: Type): Info = typ match {
       case TArray(_, dims) => {
@@ -110,4 +142,47 @@ object TypeEnv {
       case _ => Info(id, typ, Map(), Map())
     }
   }
+
+  private case class Env(
+    e: List[Map[Id, Info]],
+    caps: List[Map[Expr, Capability]]) extends Environment {
+
+    type Stack[T] = List[T]
+    type TypeScope = Map[Id, Info]
+    type CapScope = Map[Expr, Capability]
+
+    def addScope = Env(Map[Id, Info]() :: e, Map[Expr, Capability]() :: caps)
+    def endScope = (Env(e.tail, caps.tail), e.head)
+    def apply(id: Id): Info = find(e, id) match {
+      case Some(info) => info
+      case None => throw UnboundVar(id)
+    }
+
+    def getCap(expr: Expr): Option[Capability] =
+      caps.find(c => c.get(expr).isDefined).map(c => c(expr))
+
+    def addCap(expr: Expr, cap: Capability) =
+      Env(e, caps.head + (expr -> cap) :: caps.tail)
+
+    private def find(e: Stack[TypeScope], id: Id): Option[Info] =
+      e.find(m => m.get(id).isDefined) match {
+        case None => None
+        case Some(map) => Some(map(id))
+      }
+
+    def add(bind: (Id, Info)) = find(e, bind._1) match {
+      case Some(_) => throw AlreadyBound(bind._1)
+      case None => Env(e.head + bind :: e.tail, caps)
+    }
+    def update(bind: (Id, Info)) = find(e, bind._1) match {
+      case None => throw UnboundVar(bind._1)
+      case Some(_) => {
+        val scope = e.indexWhere(m => m.get(bind._1).isDefined)
+        Env(e.updated(scope, e(scope) + bind), caps)
+      }
+    }
+    def ++(binds: TypeScope) =
+      binds.foldLeft[Environment](this)({ case (e, b) => e.add(b) })
+  }
+
 }

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -267,8 +267,8 @@ class TypeCheckerSpec extends FunSpec {
         a[1]
         """ )
     }
-    it("cannot create different capabilities in branches") {
-      assertThrows[InvalidCap] {
+    it("can create different capabilities in branches") {
+      // See discussion in: https://github.com/cucapra/seashell/pull/81
         typeCheck("""
           decl a: bit<10>[2 bank 2];
           if (true) {
@@ -277,7 +277,6 @@ class TypeCheckerSpec extends FunSpec {
             let x = a[0];
           }
           """ )
-      }
     }
   }
 

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -222,6 +222,63 @@ class TypeCheckerSpec extends FunSpec {
         typeCheck("if (1) { let x = 10; }")
       }
     }
+    it("cannot consume same banks in sequenced statements") {
+      assertThrows[AlreadyConsumed] {
+        typeCheck("""
+          decl a: bit<10>[2 bank 2];
+          if (true) {
+            a[0]
+          };
+          a[0]
+          """ )
+      }
+    }
+    it("cannot consume same banks in sequenced statements from else branch") {
+      assertThrows[AlreadyConsumed] {
+        typeCheck("""
+          decl a: bit<10>[2 bank 2];
+          if (true) {
+            a[0]
+          } else {
+            a[1]
+          };
+          a[1]
+          """ )
+      }
+    }
+    it("can consume same banks in branches") {
+      typeCheck("""
+        decl a: bit<10>[10];
+        if (true) {
+          a[0]
+        } else {
+          a[0]
+        }
+        """ )
+    }
+    it("can consume bank in sequenced statement not used in either branch") {
+      typeCheck("""
+        decl a: bit<10>[2 bank 2];
+        if (true) {
+          a[0]
+        } else {
+          a[0]
+        };
+        a[1]
+        """ )
+    }
+    it("cannot create different capabilities in branches") {
+      assertThrows[InvalidCap] {
+        typeCheck("""
+          decl a: bit<10>[2 bank 2];
+          if (true) {
+            a[0] := 1;
+          } else {
+            let x = a[0];
+          }
+          """ )
+      }
+    }
   }
 
   describe("while loops") {


### PR DESCRIPTION
Fixes #76.

The type checker implements mostly we talked about in the meeting. The one new behavior is that both branches are required to use expressions that acquire capabilities in the same way. One branch cannot write into an array access while the other tries to read from it.

Also, this PR restructures `Environment` to better hide implementation details and even adds comments for it's methods!