### PR TITLE
adding TSizedInt rule for consumeBanks

### DIFF
--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -42,6 +42,9 @@ object Errors {
   case class AlreadyConsumed(id: Id, dim: Int, bank: Int) extends TypeError(
     s"Bank $bank in dimension $dim of $id already consumed.")
 
+  case class InvalidDynamicIndex(id:Id, bf:Int) extends TypeError(
+    s"Dynamic access of array $id requires unbanked array. Actual banking factor: $bf. Use a shrink view to create unbanked array.", id.pos)
+
   // Invalid Capability error
   case class InvalidCap(expr: Expr, exp: Capability, actual: Capability) extends TypeError(
     s"This expression requires $exp capability, but previous usage inferred $actual capability.", expr.pos)

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -84,6 +84,10 @@ object TypeChecker {
           env2.update(id, env2(id).consumeDim(i, e - s)) -> bres * (e - s)
         case (TStaticInt(v), env2) =>
           env2.update(id, env(id).consumeBank(i, v % dims(i)._2)) -> bres * 1
+        case (TSizedInt(_), env2) =>
+          if (dims(i)._2 != 1) throw InvalidDynamicIndex(id, dims(i)._2)
+          else env2.update(id, env(id).consumeBank(i, 0)) -> bres * 1
+
         case (t, _) => throw InvalidIndex(id, t)
       }
     })

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -769,15 +769,13 @@ class TypeCheckerSpec extends FunSpec {
         """ )
     }
 
-    it("with arithmetic cannot be used for access") {
-      assertThrows[InvalidIndex] {
-        typeCheck("""
-          decl a: bit<10>[10];
-          for (let i = 0..10) {
-            a[i * 2];
-          }
-          """ )
-      }
+    it("with arithmetic, can be used for access") {
+      typeCheck("""
+        decl a: bit<10>[10];
+        for (let i = 0..10) {
+          a[i * 2];
+        }
+        """ )  
     }
   }
 
@@ -920,16 +918,16 @@ class TypeCheckerSpec extends FunSpec {
     }
   }
 
-  // XXX(rachit): This seems like confusing behavior.
-  describe("Indexing with static var") {
-    it("works without reassigning") {
-      typeCheck("decl a: bit<32>[10]; let x = 1; a[x]")
+  describe("Indexing with dynamic (sized) var") {
+    it("works with an unbanked array") {
+      typeCheck("decl a: bit<10>[10]; decl x: bit<10>; a[x] := 5")
     }
-    it("doesnt work with reassigning") {
-      assertThrows[InvalidIndex] {
-        typeCheck("decl a: bit<32>[10]; let x = 1; x := 2; a[x]")
+    it ("doesn't work with banked array") {
+      assertThrows[InvalidDynamicIndex] {
+        typeCheck("decl a: bit<10>[10 bank 5]; decl x: bit<10>; a[x] := 5")
       }
     }
   }
+
 
 }


### PR DESCRIPTION
Addresses issue #70 . 
Checks if the array is unbanked (by checking if its banking factor is 1), and if it is, consumes bank 0.

Not sure about the error to throw here, or if bres * 1 is the correct mapping here.
