### PR TITLE
Subtyping is hard

### DIFF
--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -56,8 +56,8 @@ object Errors {
     extends TypeError(s"Array access implies $ac safe writes are possible, but surrounding context requires $exp copies.", expr.pos)
 
   // Subtyping error
-  case class NoJoin(t1: Type, t2: Type) extends TypeError(
-    s"$t1 and $t2 are incomparable. Cannot create a join.")
+  case class NoJoin(pos: Position, cons: String, t1: Type, t2: Type) extends TypeError(
+    s"$t1 and $t2 are incomparable. Cannot create a join for construct $cons.", pos)
 
   // Operation errors
   case class BinopError(op: BOp, t1: Type, t2: Type) extends TypeError(

--- a/src/main/scala/Subtyping.scala
+++ b/src/main/scala/Subtyping.scala
@@ -1,0 +1,51 @@
+package fuselang
+
+import scala.math.{max,log10,ceil}
+import Syntax._
+import Errors.NoJoin
+
+/**
+ * Subtyping relations are only defined over the number hierarchy. Read 't1 < t2'
+ * as t1 is subtype of t2. The subtyping hierarchy is:
+ *
+ * sized(n) > sized(n - 1) ... > sized(1) > idx > static
+ *
+ * Note that all idx types and static types are equal to each other.
+ */
+object Subtyping {
+  def bitsNeeded(n: Int) = n match {
+    case 0 => 1
+    case n => ceil(log10(n)/log10(2)).toInt + 1
+  }
+
+  def areEqual(t1: Type, t2: Type) = (t1, t2) match {
+    case (_:TStaticInt, _:TStaticInt) => true
+    case (_:TIndex, _:TIndex) => true
+    case _ => t1 == t2
+  }
+  def isSubtype(sub: Type, sup: Type): Boolean = (sub, sup) match {
+    case (TSizedInt(v1), TSizedInt(v2)) => v1 <= v2
+    case (_:IntType, _:TSizedInt) => true
+    case (_:TStaticInt, _:TIndex) => true
+    case (TArray(tsub, _), TArray(tsup, _)) => isSubtype(tsup, tsub)
+    case _ => areEqual(sub, sup)
+  }
+
+  def joinOf(t1: Type, t2: Type, op: (Int, Int) => Int) = (t1, t2) match {
+    case (TStaticInt(v1), TStaticInt(v2)) => TStaticInt(op(v1, v2))
+    case (TSizedInt(s1), TSizedInt(s2)) => TSizedInt(max(s1, s2))
+    case (TStaticInt(v), TSizedInt(s)) => {
+      TSizedInt(max(s, bitsNeeded(v)))
+    }
+    case (TSizedInt(s), TStaticInt(v)) => {
+      TSizedInt(max(s, bitsNeeded(v)))
+    }
+    case (idx@TIndex(_, _), TStaticInt(v)) =>
+      TSizedInt(max(idx.maxVal, bitsNeeded(v)))
+    case (TStaticInt(v), idx@TIndex(_, _)) =>
+      TSizedInt(max(idx.maxVal, bitsNeeded(v)))
+    case (_: TIndex, t2@TSizedInt(_)) => t2
+    case (t2@TSizedInt(_), _:TIndex) => t2
+    case (t1, t2) => throw NoJoin(t1, t2)
+  }
+}

--- a/src/main/scala/Subtyping.scala
+++ b/src/main/scala/Subtyping.scala
@@ -11,6 +11,32 @@ import Errors.NoJoin
  * sized(n) > sized(n - 1) ... > sized(1) > idx > static
  *
  * Note that all idx types and static types are equal to each other.
+ *
+ * Subtyping and joins:
+ *
+ *      a1
+ *      |        b1
+ *      a2       |
+ *      |        b2
+ *      a3       |
+ *      |        |
+ *      +---+----+
+ *          |
+ *          c1
+ *          |
+ *          c2
+ *
+ *  If a, b, c are types, then we have the definitions:
+ *
+ *  Subtyping: t1 < t2 iff there is a path from t1 to t2 such that the links
+ *  only go down.
+ *  Example: a1 < a2 == true, a1 < c1 == true, a1 < b1 == false
+ *
+ *  For subtyping, a types and b types are called "incomparable".
+ *
+ *  Joins: t1 and t2 have a join T if t1 < T and t2 < T. Informally, this is
+ *  described as descending down the trees of t1 and t2 to find a common ancestor.
+ *  Canonically, we call this type the "least upper bound"
  */
 object Subtyping {
   def bitsNeeded(n: Int) = n match {
@@ -19,10 +45,11 @@ object Subtyping {
   }
 
   def areEqual(t1: Type, t2: Type) = (t1, t2) match {
-    case (_:TStaticInt, _:TStaticInt) => true
+    case (TStaticInt(v1), TStaticInt(v2)) => v1 == v2
     case (_:TIndex, _:TIndex) => true
     case _ => t1 == t2
   }
+
   def isSubtype(sub: Type, sup: Type): Boolean = (sub, sup) match {
     case (TSizedInt(v1), TSizedInt(v2)) => v1 <= v2
     case (_:IntType, _:TSizedInt) => true
@@ -32,6 +59,11 @@ object Subtyping {
       areEqual(tsup, tsub)
     }
     case _ => areEqual(sub, sup)
+  }
+
+  def hasJoin(t1: Type, t2: Type): Boolean = (t1, t2) match {
+    case (_:IntType, _:IntType) => true
+    case _ => false
   }
 
   def joinOf(t1: Type, t2: Type, op: (Int, Int) => Int) = (t1, t2) match {

--- a/src/main/scala/Subtyping.scala
+++ b/src/main/scala/Subtyping.scala
@@ -27,7 +27,10 @@ object Subtyping {
     case (TSizedInt(v1), TSizedInt(v2)) => v1 <= v2
     case (_:IntType, _:TSizedInt) => true
     case (_:TStaticInt, _:TIndex) => true
-    case (TArray(tsub, _), TArray(tsup, _)) => isSubtype(tsup, tsub)
+    case (TArray(tsub, _), TArray(tsup, _)) => {
+      // Arrays are mutable so we are conservative and disallow subtyping.
+      areEqual(tsup, tsub)
+    }
     case _ => areEqual(sub, sup)
   }
 

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -30,7 +30,7 @@ object Syntax {
     }
   }
   // Types that can be upcast to Ints
-  trait IntType
+  sealed trait IntType
   case class TSizedInt(len: Int) extends Type with IntType
   case class TStaticInt(v: Int) extends Type with IntType
   case class TIndex(static: (Int, Int), dynamic: (Int, Int)) extends Type with IntType {
@@ -67,40 +67,45 @@ object Syntax {
       case _:OpBXor => "^"
     }
 
-    def toFun: (Int, Int) => Int = this match {
-      case _:OpAdd => _ + _
-      case _:OpMul => _ * _
-      case _:OpDiv => _ / _
-      case _:OpSub => _ - _
-      case _:OpBAnd => _ & _
-      case _:OpBOr => _ | _
-      case _:OpBXor => _ ^ _
-      case _ => throw MsgError(s"toFun not defined on $this")
+    def toFun: Option[(Int, Int) => Int] = this match {
+      case _:OpAdd => Some(_ + _)
+      case _:OpMul => Some(_ * _)
+      case _:OpDiv => Some(_ / _)
+      case _:OpSub => Some(_ - _)
+      case _:OpBOr => Some(_ | _)
+      case _:OpBAnd => Some(_ & _)
+      case _:OpBXor => Some(_ ^ _)
+      case _ => None
     }
   }
-  // comparison ops
-  case class OpEq() extends BOp
-  case class OpNeq() extends BOp
-  case class OpLt() extends BOp
-  case class OpLte() extends BOp
-  case class OpGt() extends BOp
-  case class OpGte() extends BOp
+  // Equality ops
+  sealed trait EqOp
+  case class OpEq() extends BOp with EqOp
+  case class OpNeq() extends BOp with EqOp
+  // Comparison ops
+  sealed trait CmpOp
+  case class OpLt() extends BOp with CmpOp
+  case class OpGt() extends BOp with CmpOp
+  case class OpLte() extends BOp with CmpOp
+  case class OpGte() extends BOp with CmpOp
   // Boolean ops
-  case class OpAnd() extends BOp
-  case class OpOr() extends BOp
+  sealed trait BoolOp
+  case class OpAnd() extends BOp with BoolOp
+  case class OpOr() extends BOp with BoolOp
   // integer/float ops
-  case class OpAdd() extends BOp
-  case class OpSub() extends BOp
-  case class OpMul() extends BOp
-  case class OpDiv() extends BOp
-  case class OpMod() extends BOp
-  // Shifting ops
-  case class OpLsh() extends BOp
-  case class OpRsh() extends BOp
+  sealed trait NumOp
+  case class OpAdd() extends BOp with NumOp
+  case class OpSub() extends BOp with NumOp
+  case class OpMul() extends BOp with NumOp
+  case class OpDiv() extends BOp with NumOp
+  case class OpMod() extends BOp with NumOp
   // Bit ops
-  case class OpBAnd() extends BOp
-  case class OpBOr() extends BOp
-  case class OpBXor() extends BOp
+  sealed trait BitOp
+  case class OpLsh() extends BOp with BitOp
+  case class OpRsh() extends BOp with BitOp
+  case class OpBOr() extends BOp with BitOp
+  case class OpBAnd() extends BOp with BitOp
+  case class OpBXor() extends BOp with BitOp
 
   sealed trait Expr extends Positional {
     def isLVal = this match {

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -153,22 +153,19 @@ class TypeCheckerSpec extends FunSpec {
     it("comparisons on floats returns a boolean") {
       typeCheck("if (2.5 < 23.5) { 1 }")
     }
-
     it("can add sized int to static int") {
       typeCheck("decl x: bit<64>; let y = 1; x + y;")
     }
-
     it("can add floats") {
       typeCheck("decl f: float; let y = 1.5; f + y")
     }
-
     it("cannot add int and float") {
-      assertThrows[BinopError] {
+      assertThrows[NoJoin] {
         typeCheck("1 + 2.5")
       }
     }
     it("cannot add float dec and int") {
-      assertThrows[BinopError] {
+      assertThrows[NoJoin] {
         typeCheck("decl f: float; f + 1")
       }
     }
@@ -650,7 +647,7 @@ class TypeCheckerSpec extends FunSpec {
     }
 
     it("do not return values") {
-      assertThrows[BinopError] {
+      assertThrows[NoJoin] {
         typeCheck("""
           def bar(a: bit<10>) { a }
           1 + bar(10)
@@ -707,7 +704,7 @@ class TypeCheckerSpec extends FunSpec {
       }
     }
     it("has the same type as the underlying array") {
-      assertThrows[BinopError] {
+      assertThrows[NoJoin] {
         typeCheck("""
           decl a: bool[10 bank 5];
           view v = shrink a[0 : 5];
@@ -936,7 +933,7 @@ class TypeCheckerSpec extends FunSpec {
   }
 
   describe("subtyping relations") {
-    ignore("static ints are always subtypes") {
+    it("static ints are always subtypes") {
       typeCheck("1 == 2")
     }
 

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -935,5 +935,47 @@ class TypeCheckerSpec extends FunSpec {
     }
   }
 
+  describe("subtyping relations") {
+    ignore("static ints are always subtypes") {
+      typeCheck("1 == 2")
+    }
 
+    it("smaller sized ints are subtypes of larger sized ints") {
+      typeCheck("""
+        decl x: bit<16>;
+        decl y: bit<32>;
+        x == y
+        """ )
+    }
+
+    it("static ints are subtypes of index types") {
+      typeCheck("""
+        for (let i = 0..12) {
+          i == 1
+        }
+        """ )
+    }
+
+    it("index types are subtypes of sized ints") {
+      typeCheck("""
+        decl x: bit<32>;
+        for (let i = 0..12) {
+          i == x
+        }
+        """ )
+    }
+
+    it("Array subtyping is not allowed") {
+      assertThrows[UnexpectedSubtype] {
+        typeCheck("""
+          def foo(b: bit<10>[10]) {
+            b[0] := 10; // overflows
+          }
+
+          decl a: bit<2>[10];
+          foo(a)
+          """ )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #53. Fixes #95. Fixes #87.

Three important things:
- Explicit subtyping hierarchy: sized int > idx types > static ints
- `let x = 1` `x` gets the type `TSizedInt(bitsNeeded(1))`.
- Only numbers and binary operations on numbers can a static type. So `a[0]` still works fine, but `let x = 1; a[x];` doesn't.