### PR TITLE
make `fuse` command insensitve to links

### DIFF
--- a/fuse
+++ b/fuse
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-here=`dirname $(readlink $0) || dirname $0`
+here=`dirname $(readlink $0 || echo $0)`
 java -jar $here/target/scala-2.12/fuse.jar $@

--- a/fuse
+++ b/fuse
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-here=`dirname $0`
+here=`dirname $(readlink $0) || dirname $0`
 java -jar $here/target/scala-2.12/fuse.jar $@


### PR DESCRIPTION
@sampsyo or @sa2257 can you make sure this won't break buildbot setup? Once we have this, we can freely link `fuse` globally or put it on the path.