### PR TITLE
External functions

### DIFF
--- a/docs/binders.md
+++ b/docs/binders.md
@@ -73,7 +73,7 @@ declared using the `extern` keyword.
 def extern print_vector(c: float[4]);
 ```
 
-Backends can either provide their implementations for `externs` (for example
+Backends can either provide their implementations for `extern`s (for example
 to implement printing when running on CPUs) or erase the calls completely.
 
 For more details on the exact hardware semantics see here **TODO**.

--- a/docs/binders.md
+++ b/docs/binders.md
@@ -66,4 +66,14 @@ def foo(x: bit<10>, y: bit<10>) {
 }
 ```
 
+External functions, such as functions provided by header files, can be
+declared using the `extern` keyword.
+
+```
+def extern print_vector(c: float[4]);
+```
+
+Backends can either provide their implementations for `externs` (for example
+to implement printing when running on CPUs) or erase the calls completely.
+
 For more details on the exact hardware semantics see here **TODO**.

--- a/docs/cpp-runnable.md
+++ b/docs/cpp-runnable.md
@@ -20,6 +20,8 @@ the executable.
 As an example, we'll be using the following fuse code:
 
 ```C
+def extern print_vector(c: float[4]);
+
 decl a: float[2][2];
 decl b: float[2][2];
 decl c: float[2][2];
@@ -29,9 +31,12 @@ for (let i = 0..2) {
     c[i][j] := a[i][j] + b[i][j];
   }
 }
+---
+print_vector(c);
 ```
 
-Add this code to a file titled `matadd.fuse`.
+Add this code to a file titled `matadd.fuse`. The `print_vector` extern is
+provided by the parsing library.
 
 Next, run the command:
 
@@ -41,13 +46,8 @@ fuse run matadd.fuse -o matadd.cpp
 
 the command will something similar to the following:
 
-```sh
-g++ --std=c++11 -Wall -Isrc/main/resources/headers matadd.cpp -o matadd.cpp.o
-```
-
 When the command succeeds, it will add two new files to the directory --
-`matadd.cpp` and `matadd.cpp.out`. Remember the output from above, we'll use it
-in a later step.
+`matadd.cpp` and `matadd.cpp.out`.
 
 Create another file titled `data.json` with the following contents:
 
@@ -61,23 +61,6 @@ Create another file titled `data.json` with the following contents:
 
 and run the command:
 
-```
-./matadd.cpp.out data.json
-```
-
-You should see no output indicating that the program ran successfully. However,
-this is not very useful. To see an output, open `matadd.cpp` and add the following
-line after the call to `kernel`:
-
-```C
-int main {
-  ...
-  kernel(a, b, c); // Already present
-  print_vector(c); // Provided by picojson
-}
-```
-
-and the run the `g++` command produced by `fuse run` earlier followed by
 ```
 ./matadd.cpp.out data.json
 ```

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -223,8 +223,11 @@ private class FuseParser extends RegexParsers with PackratParsers {
     }
   }
   lazy val funcDef: P[FuncDef] = positioned {
+    "def" ~ "extern" ~> iden ~ parens(repsep(args, ",")) <~ ";" ^^ {
+      case fn ~ args  => FuncDef(fn, args, None)
+    } |
     "def" ~> iden ~ parens(repsep(args, ",")) ~ block ^^ {
-      case fn ~ args ~ body => FuncDef(fn, args, body)
+      case fn ~ args ~ body => FuncDef(fn, args, Some(body))
     }
   }
   lazy val defs = funcDef | recordDef

--- a/src/main/scala/RewriteView.scala
+++ b/src/main/scala/RewriteView.scala
@@ -98,7 +98,7 @@ object RewriteView {
   def rewriteProg(p: Prog): Prog = {
     val emptyEnv = Map[Id, List[Expr] => Expr]()
     val fs = p.defs.map(defi => defi match {
-      case fdef@FuncDef(_, _, b) => fdef.copy(body = rewriteC(b)(emptyEnv)._1)
+      case fdef@FuncDef(_, _, bOpt) => fdef.copy(bodyOpt = bOpt.map(b => rewriteC(b)(emptyEnv)._1))
       case _ => defi
     })
     val cmdn = rewriteC(p.cmd)(emptyEnv)._1

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -173,7 +173,7 @@ object Syntax {
   case object CEmpty extends Command
 
   sealed trait Definition extends Positional
-  case class FuncDef(id: Id, args: List[Decl], body: Command) extends Definition
+  case class FuncDef(id: Id, args: List[Decl], bodyOpt: Option[Command]) extends Definition
   case class RecordDef(name: Id, fields: Map[Id, Type]) extends Definition {
     fields.foreach({ case (f, t) => t match {
       case _:TArray => throw ArrayInRecord(name, f, t)

--- a/src/main/scala/Syntax.scala
+++ b/src/main/scala/Syntax.scala
@@ -173,6 +173,10 @@ object Syntax {
   case object CEmpty extends Command
 
   sealed trait Definition extends Positional
+  /**
+   * Represents function definitions. A missing function body implies that
+   * this is an extern function.
+   */
   case class FuncDef(id: Id, args: List[Decl], bodyOpt: Option[Command]) extends Definition
   case class RecordDef(name: Id, fields: Map[Id, Type]) extends Definition {
     fields.foreach({ case (f, t) => t match {

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -54,13 +54,13 @@ object TypeChecker {
   }
 
   private def checkDef(defi: Definition, env: Environment) = defi match {
-    case FuncDef(id, args, body) => {
+    case FuncDef(id, args, bodyOpt) => {
       val envWithArgs = args.foldLeft(env.addScope)({ case (env, Decl(id, typ)) =>
         val rTyp = env.resolveType(typ)
         id.typ = Some(rTyp);
         env.add(id, rTyp)
       })
-      val bodyEnv = checkC(body)(envWithArgs, 1)
+      val bodyEnv = bodyOpt.map(body => checkC(body)(envWithArgs, 1)).getOrElse(envWithArgs)
       bodyEnv.endScope._1.add(id, TFun(args.map(_.typ)))
     }
     case RecordDef(name, fields) => {

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -127,12 +127,13 @@ object Cpp {
       case _ => s"${emitType(d.typ)} ${d.id}"
     }
 
-    def emitFunc: FuncDef => Doc = { case func@FuncDef(id, args, body) =>
+    def emitFunc: FuncDef => Doc = { case func@FuncDef(id, args, bodyOpt) =>
       val as = hsep(args.map(emitDecl), comma)
-      "void" <+> id <> parens(as) <+> scope {
+      // If body is not defined, this is an extern. Elide the definition.
+      bodyOpt.map(body => "void" <+> id <> parens(as) <+> scope {
         emitFuncHeader(func) <@>
         body
-      }
+      }).getOrElse(value(""))
     }
 
     def emitDef(defi: Definition): Doc = defi match {

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -93,7 +93,7 @@ private class CppRunnable extends CppLike {
   def emitProg(p: Prog, c: Config) = {
     val prog =
       vsep(p.defs.map(emitDef)) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, p.cmd))
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))
 
     val getArgs: Doc = vsep(p.decls.map(emitParseDecl), line)
 

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -51,7 +51,7 @@ private class VivadoBackend extends CppLike {
   def emitProg(p: Prog, c: fuselang.Utils.Config): String = {
     val layout =
       vsep(p.defs.map(emitDef)) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, p.cmd))
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))
 
     super.pretty(layout).layout
   }

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -128,6 +128,16 @@ class ParsingTests extends org.scalatest.FunSuite {
       """ )
   }
 
+  test("external functions") {
+    parseAst("""
+      def extern foo(a: bit<32>);
+      """ )
+
+    parseAst("""
+      def extern foo(a: bit<32>[10 bank 5], b: bool);
+      """ )
+  }
+
   test("views") {
     parseAst("""
       view v_a = shrink a[4 * i : 4]

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -616,12 +616,18 @@ class TypeCheckerSpec extends FunSpec {
       }
     }
 
-    it("do no allow recursion") {
+    it("do not allow recursion") {
       assertThrows[UnboundVar] {
         typeCheck("""
           def bar(a: bool) { bar(a) }
           """ )
       }
+    }
+
+    it("allow externs to be defined") {
+      typeCheck("""
+        def extern bar(a: bool);
+        """ )
     }
   }
 
@@ -651,6 +657,28 @@ class TypeCheckerSpec extends FunSpec {
         typeCheck("""
           def bar(a: bit<10>) { a }
           1 + bar(10)
+          """ )
+      }
+    }
+  }
+
+  describe("Function applications w/ externs") {
+    it("require the correct types") {
+      assertThrows[UnexpectedSubtype] {
+        typeCheck("""
+          def extern bar(a: bool);
+          bar(1)
+          """ )
+      }
+    }
+
+    it("completely consume array parameters") {
+      assertThrows[AlreadyConsumed] {
+        typeCheck("""
+          def extern bar(a: bit<10>[10 bank 5]);
+          decl x: bit<10>[10 bank 5];
+          bar(x);
+          x[1]
           """ )
       }
     }


### PR DESCRIPTION
Add support for specifying external functions:
```
def extern print_vector(a: float[10]);
print_vector(a)
```

`extern` functions are only checked using their function signatures. Different backends can decide to do different things for each `extern`. `vivado` and `c++` remove all `extern` defs but keep calls to them. This allows us to use functions provided by header files.

Other backends might do different things for each `extern`. For example, a backend might decide to provide the implementation of `print_vector` in its implementation.