### PR TITLE
Fixing CSeq type checking rule

### DIFF
--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -360,9 +360,10 @@ object TypeChecker {
     case CExpr(e) => checkE(e)._2
     case CEmpty => env
     case CSeq(c1, c2) => {
-      val _ = checkC(c1)
-      val e2 = checkC(c2)(env, rres)
-      // FIXME(rachit): This should probably be intersection of e1 and e2
+      val newscope = env.addScope
+      val e1 = checkC(c1)(newscope, rres)
+      val (_, binds, _) = e1.endScope
+      val e2 = checkC(c2)(env ++ binds, rres)
       e2
     }
   }

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -394,6 +394,25 @@ class TypeCheckerSpec extends FunSpec {
           """ )
       }
     }
+
+    it("allow declarations in first statement to be used in second") {
+      typeCheck("""
+              let bucket_idx = 10;
+              ---
+              bucket_idx := 20;
+         """)
+    }
+
+    it("check for declarations used in both branches") {
+      typeCheck("""
+              let test_var = 10;
+              {
+                test_var := 50;
+                ---
+                test_var := 30;
+              }
+         """)
+    }
   }
 
   describe("Parallel composition") {
@@ -406,6 +425,30 @@ class TypeCheckerSpec extends FunSpec {
           let y = a[i];
         }
         """ )
+    }
+
+    it("allows same banks to be used with reassignment") {
+      typeCheck("""
+        decl a: bit<10>[20 bank 10];
+        for (let i = 0..20) unroll 10 {
+          a[i] := 5;
+          ---
+          a[i] := 2;
+        }
+      """)
+    }
+
+    it("reuses banks of multidimensional array") {
+      typeCheck("""
+        decl a: bit<10>[20 bank 10][10 bank 5];
+        for (let i = 0..20) unroll 10 {
+          for (let j = 0..10) unroll 5 {
+            a[i][j] := 5;
+            ---
+            a[i][j] := 3;
+          }
+        }
+      """)
     }
   }
 
@@ -501,29 +544,6 @@ class TypeCheckerSpec extends FunSpec {
               }
           """ )
     }
-
-    it("Allow declarations in first statement to be used in second") {
-      typeCheck("""
-              let bucket_idx = 10;
-              ---
-              bucket_idx := 20;
-         """)
-      
-    }
-
-    it("Check for declarations used in both branches") {
-      typeCheck("""
-              let test_var = 10;
-              {
-                test_var := 50;
-                ---
-                test_var := 30;
-              }
-         """)
-      
-    }
-
-
   }
 
   describe("Capabilities in unrolled context") {

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -502,6 +502,27 @@ class TypeCheckerSpec extends FunSpec {
           """ )
     }
 
+    it("Allow declarations in first statement to be used in second") {
+      typeCheck("""
+              let bucket_idx = 10;
+              ---
+              bucket_idx := 20;
+         """)
+      
+    }
+
+    it("Check for declarations used in both branches") {
+      typeCheck("""
+              let test_var = 10;
+              {
+                test_var := 50;
+                ---
+                test_var := 30;
+              }
+         """)
+      
+    }
+
 
   }
 


### PR DESCRIPTION
Fixes #51 
Creates a new scope in the environment; typechecks `c1`; extracts any new bindings from this typechecking; adds the new bindings to the initial environment and typechecks `c2`.