### PR TITLE
buildbot: Interface to manually set a job's state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ RUN cd /opt && \
     rm sbt-${SBT_VERSION}.tgz && \
     sbt version
 
-# Add Python, pipenv, and node for buildbot.
-RUN apk add python3 py3-pip nodejs-current yarn
+# Add Python, pipenv, and node for buildbot. The buildbot also needs OpenSSH
+# and the sshpass utility for its Zynq execution stage.
+RUN apk add python3 py3-pip nodejs-current yarn \
+    openssh sshpass
 RUN pip3 install pipenv
 
 # Volume, port, and command for buildbot.

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -33,8 +33,9 @@ STATUS_STRINGS = {
     state.HLS_FINISH: "Synthesized",
     state.RUN: "Running",
     state.DONE: "Done",
-    state.FAIL: "Failed"
+    state.FAIL: "Failed",
 }
+
 
 def _get(job_name):
     """Get a job by name, or raise a 404 error."""
@@ -166,7 +167,8 @@ def jobs_html():
     return flask.render_template(
         'joblist.html',
         jobs=db._all(),
-        status_strings=STATUS_STRINGS)
+        status_strings=STATUS_STRINGS,
+    )
 
 
 @app.route('/live.html')

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -4,7 +4,7 @@ import os
 from io import StringIO
 import csv
 from . import workproc
-from .db import JobDB, ARCHIVE_NAME, CODE_DIR, NotFoundError
+from .db import JobDB, ARCHIVE_NAME, CODE_DIR, NotFoundError, log
 from datetime import datetime
 import re
 from . import state
@@ -176,9 +176,15 @@ def live_html():
     return flask.render_template('live.html')
 
 
-@app.route('/jobs/<name>.html')
+@app.route('/jobs/<name>.html', methods=['GET', 'POST'])
 def show_job(name):
     job = _get(name)
+
+    # Possibly update the job.
+    if request.method == 'POST':
+        new_state = request.form['state']
+        log(job, 'manual state change')
+        db.set_state(job, new_state)
 
     # Find all the job's files.
     job_dir = db.job_dir(name)

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -189,7 +189,12 @@ def show_job(name):
             if not fn.startswith('.'):
                 paths.append(os.path.join(dp, fn))
 
-    return flask.render_template('job.html', job=job, files=paths)
+    return flask.render_template(
+        'job.html',
+        job=job,
+        files=paths,
+        status_strings=STATUS_STRINGS,
+    )
 
 
 @app.route('/jobs/<name>')

--- a/buildbot/buildbot/state.py
+++ b/buildbot/buildbot/state.py
@@ -1,4 +1,4 @@
-# Define various states workers can be in
+# These are the states that jobs can be in.
 
 UPLOAD = "uploaded"
 UNPACK = "unpacking"

--- a/buildbot/buildbot/static/style.css
+++ b/buildbot/buildbot/static/style.css
@@ -48,6 +48,9 @@ ul.log pre {
 form {
     margin-bottom: 1rem;
 }
+form.inline {
+    display: inline;
+}
 form p {
     display: inline-block;
     margin: 0;
@@ -91,7 +94,7 @@ textarea {
   color: white;
 }
 
-.hlsed, .hlsing {
+.hlsed {
   background-color: #db9a59;
   color: white;
 }

--- a/buildbot/buildbot/templates/job.html
+++ b/buildbot/buildbot/templates/job.html
@@ -8,7 +8,19 @@
     </li>
     <li>
         <b>state:</b>
-        {{ job.state }}
+        {{ status_strings[job.state] }}
+
+        <form action="" method="post" class="inline">
+            <select name="state">
+                {% for state, name in status_strings.items() -%}
+                <option value="{{ state }}"
+                    {%- if state == job.state %}selected{% endif %}>
+                    {{ name }}
+                </option>
+                {%- endfor %}
+            </select>
+            <input type="submit" value="Set">
+        </form>
     </li>
     {% for key, value in job.items() %}
     {% if key not in ('started', 'state', 'name', 'log') %}

--- a/buildbot/buildbot/templates/joblist.html
+++ b/buildbot/buildbot/templates/joblist.html
@@ -29,6 +29,7 @@ Or see the <a href="{{ url_for('live_html') }}">live interface</a>.
     <thead>
         <tr>
             <th>Id</th>
+            <th>Name</th>
             <th>Start Time</th>
             <th>Status</th>
         </tr>
@@ -41,6 +42,7 @@ Or see the <a href="{{ url_for('live_html') }}">live interface</a>.
                     {{ job.name }}
                 </a>
             </td>
+            <td>{{ job.hw_basename }}</td>
             <td>{{ job.started | dt }}</td>
             <td class="{{ job.state }} status">{{ status_strings[job.state] }}</td>
         </tr>


### PR DESCRIPTION
As discussed in #32, and as requested by @rachitnigam, this adds a little popup on each job page that lets you manually change the state of a job. This is especially useful to "rewind" a failed job to an earlier stage to try it again after a code change.

<img width="479" alt="Screenshot 2019-03-14 14 19 17" src="https://user-images.githubusercontent.com/188033/54381488-51873480-4664-11e9-9370-90223f1aed02.png">
