### PR TITLE
buildbot: Notify workers when manually changing state

### DIFF
--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -185,6 +185,7 @@ def show_job(name):
         new_state = request.form['state']
         log(job, 'manual state change')
         db.set_state(job, new_state)
+        notify_workers(job['name'])
 
     # Find all the job's files.
     job_dir = db.job_dir(name)


### PR DESCRIPTION
Quick fix for #126, which changed the state but neglected to tell the worker process that anything had changed.