### PR TITLE
buildbot: Move jobs' file lists and logs to separate subpages

### DIFF
--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -204,6 +204,16 @@ def show_job(name):
     )
 
 
+@app.route('/jobs/<name>/log.html')
+def job_log(name):
+    job = _get(name)
+
+    return flask.render_template(
+        'log.html',
+        job=job,
+    )
+
+
 @app.route('/jobs/<name>')
 def get_job(name):
     job = _get(name)

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -187,19 +187,9 @@ def show_job(name):
         db.set_state(job, new_state)
         notify_workers(job['name'])
 
-    # Find all the job's files.
-    job_dir = db.job_dir(name)
-    paths = []
-    for dirpath, dirnames, filenames in os.walk(job_dir):
-        dp = os.path.relpath(dirpath, job_dir)
-        for fn in filenames:
-            if not fn.startswith('.'):
-                paths.append(os.path.join(dp, fn))
-
     return flask.render_template(
         'job.html',
         job=job,
-        files=paths,
         status_strings=STATUS_STRINGS,
     )
 
@@ -211,6 +201,26 @@ def job_log(name):
     return flask.render_template(
         'log.html',
         job=job,
+    )
+
+
+@app.route('/jobs/<name>/files.html')
+def job_files(name):
+    job = _get(name)
+
+    # Find all the job's files.
+    job_dir = db.job_dir(name)
+    paths = []
+    for dirpath, dirnames, filenames in os.walk(job_dir):
+        dp = os.path.relpath(dirpath, job_dir)
+        for fn in filenames:
+            if not fn.startswith('.'):
+                paths.append(os.path.join(dp, fn))
+
+    return flask.render_template(
+        'files.html',
+        job=job,
+        files=paths,
     )
 
 

--- a/buildbot/buildbot/static/style.css
+++ b/buildbot/buildbot/static/style.css
@@ -15,6 +15,14 @@ h2 {
     margin: 1rem 0 0.5rem;
 }
 
+h2 a:link, h2 a:visited, h3 a:link, h3 a:visited {
+    color: inherit;
+    text-decoration: none;
+}
+h2 a:hover, h3 a:hover {
+    text-decoration: underline;
+}
+
 th, td {
     padding: 0.1rem 1rem;
 }

--- a/buildbot/buildbot/templates/files.html
+++ b/buildbot/buildbot/templates/files.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>
+    Job
+    <a href="{{ url_for('show_job', name=job.name) }}">{{ job.name }}</a>:
+    Files
+</h2>
+
+<ul>
+{% for path in files %}
+    <li>
+        <a href="{{ url_for('job_file', name=job.name, filename=path) }}">
+            {{ path }}
+        </a>
+    </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/buildbot/buildbot/templates/job.html
+++ b/buildbot/buildbot/templates/job.html
@@ -43,9 +43,13 @@
 {% endfor %}
 </ul>
 
-<h3>Log</h3>
+<h3><a href="{{ url_for('job_log', name=job.name) }}">Log</a></h3>
+<p>
+    See <a href="{{ url_for('job_log', name=job.name) }}">the full log</a>
+    ({{ job.log | length }} messages).
+</p>
 <ul class="log">
-{% for time, text in job.log %}
+{% for time, text in job.log[-4:] %}
     <li>
         <time>{{ time | dt }}</time><br>
         <pre>{{ text }}</pre>

--- a/buildbot/buildbot/templates/job.html
+++ b/buildbot/buildbot/templates/job.html
@@ -32,16 +32,10 @@
     {% endfor %}
 </ul>
 
-<h3>Files</h3>
-<ul>
-{% for path in files %}
-    <li>
-        <a href="{{ url_for('job_file', name=job.name, filename=path) }}">
-            {{ path }}
-        </a>
-    </li>
-{% endfor %}
-</ul>
+<p>
+    List
+    <a href="{{ url_for('job_files', name=job.name) }}">the job’s files</a>.
+</p>
 
 <h3><a href="{{ url_for('job_log', name=job.name) }}">Log</a></h3>
 <p>

--- a/buildbot/buildbot/templates/job.html
+++ b/buildbot/buildbot/templates/job.html
@@ -37,7 +37,6 @@
     <a href="{{ url_for('job_files', name=job.name) }}">the job’s files</a>.
 </p>
 
-<h3><a href="{{ url_for('job_log', name=job.name) }}">Log</a></h3>
 <p>
     See <a href="{{ url_for('job_log', name=job.name) }}">the full log</a>
     ({{ job.log | length }} messages).

--- a/buildbot/buildbot/templates/log.html
+++ b/buildbot/buildbot/templates/log.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>
+    Job
+    <a href="{{ url_for('show_job', name=job.name) }}">{{ job.name }}</a>:
+    Log
+</h2>
+
+<ul class="log">
+{% for time, text in job.log %}
+    <li>
+        <time>{{ time | dt }}</time><br>
+        <pre>{{ text }}</pre>
+    </li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
As mentioned in #32, this makes the main job pages shorter and therefore less annoying to use. They link to separate pages for the file list and the log. The main job page still shows the last few messages from the log, but not the whole thing.

Here's what the new job page looks like:

<img width="440" alt="Screenshot 2019-03-19 21 05 30" src="https://user-images.githubusercontent.com/188033/54651904-28630b80-4a8b-11e9-9a5f-e066637ac1a5.png">
