### PR TITLE
Skip exit checks in unrolled loops

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,9 +50,3 @@ assembly := {
   getHeaders.value
   assembly.value
 }
-
-/* Running full test suite requires latest ./fuse build */
-test := {
-  assembly.value
-  (test in Test).value
-}

--- a/src/main/scala/GenerateExec.scala
+++ b/src/main/scala/GenerateExec.scala
@@ -57,16 +57,16 @@ object GenerateExec {
     }
 
     val CXX =
-      Seq("g++", "--std=c++11", "-Wall", "-I", headerLocation.toString) ++ compilerOpts
+      Seq("g++", "--std=c++14", "-Wall", "-I", headerLocation.toString) ++ compilerOpts
 
     val stderr = new StringBuilder
-    val logger = ProcessLogger(l => println(l),
+    val logger = ProcessLogger(l => scribe.info(l),
                                l => stderr ++= (l + "\n"))
 
     // Generate [[out]]. `!` is defined by sys.process:
     // https://www.scala-lang.org/api/2.12.8/scala/sys/process/index.html
     val cmd = CXX ++ Seq(src.toString, "-o", out)
-    println(cmd.mkString(" "))
+    scribe.info(cmd.mkString(" "))
     val status = cmd ! logger
 
     if (status != 0) {

--- a/src/main/scala/Logger.scala
+++ b/src/main/scala/Logger.scala
@@ -23,8 +23,8 @@ object Logger {
    * Stateful function to set the logging level in the compiler.
    */
   def setLogLevel(level: Level) = {
-    scribe.Logger.root.clearHandlers().withHandler(formatter = format,
-      minimumLevel = Some(level)).replace()
+    scribe.Logger.root.clearHandlers().withHandler(
+      formatter = format, minimumLevel = Some(level)).replace()
   }
 
   val format: Formatter = formatter"[$levelColored] $message$newLine"

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,6 +4,7 @@ import java.nio.file.{Files, Path}
 import java.io.File
 
 import Utils._
+import Compiler._
 
 object Main {
 
@@ -65,8 +66,8 @@ object Main {
     }
 
     val cppPath: Either[ErrString, Option[Path]] = prog.flatMap(prog => conf.output match {
-      case Some(out) => Compiler.compileStringToFile(prog, conf, out).map(path => Some(path))
-      case None => Compiler.compileString(prog, conf).map(res => { println(res); None })
+      case Some(out) => compileStringToFile(prog, conf, out).map(path => Some(path))
+      case None => compileString(prog, conf).map(res => { println(res); None })
     })
 
     val status: Either[ErrString, Int] = cppPath.flatMap(pathOpt => conf.mode match {

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -10,7 +10,7 @@ private class VivadoBackend extends CppLike {
 
   def unroll(n: Int) = n match {
     case 1 => ""
-    case n => s"#pragma HLS UNROLL factor=$n"
+    case n => s"#pragma HLS UNROLL factor=$n skip_exit_check"
   }
 
   def bank(id: Id, n: List[Int]): String = n.foldLeft(1)(_ * _) match {
@@ -27,7 +27,8 @@ private class VivadoBackend extends CppLike {
     "for" <> emitRange(cmd.range) <+> scope {
       unroll(cmd.range.u) <@>
       cmd.par <@>
-      (if (cmd.combine != CEmpty) text("// combiner:") <@> cmd.combine else value(""))
+      (if (cmd.combine != CEmpty) text("// combiner:") <@> cmd.combine
+       else value(""))
     }
 
   def emitFuncHeader(func: FuncDef): Doc = {

--- a/src/test/scala/RunTests.scala
+++ b/src/test/scala/RunTests.scala
@@ -52,6 +52,9 @@ object AsyncRun {
 
 class RunTests extends org.scalatest.AsyncFunSuite {
 
+  // Suppress logging infor logging.
+  Logger.setLogLevel(scribe.Level.Warn)
+
   val shouldRun = Paths.get("src/test/should-run")
   val srcFilePattern = """.*\.fuse"""
 


### PR DESCRIPTION
Emit `skip_exit_check` for unroll pragmas. According to the manual:
    
`skip_exit_check`: An optional keyword that applies only if partial unrolling is specified with `factor=`. The elimination of the exit check is dependent on whether the loop iteration count is known or unknown:
- Fixed (known) bounds: No exit condition check is performed if the iteration count is a multiple of the factor. If the iteration count is not an integer multiple of the factor, the tool:
   - Prevents unrolling.
   - Issues a warning that the exit check must be performed to proceed.
- Variable (unknown) bounds: The exit condition check is removed as requested. You must ensure that:
   - The variable bounds is an integer multiple of the specified unroll factor.
   - No exit check is in fact required.

Fixes #127.