### PR TITLE
buildbot: Tolerate bad job JSON files

### DIFF
--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -4,7 +4,7 @@ import os
 from io import StringIO
 import csv
 from . import workproc
-from .db import JobDB, ARCHIVE_NAME, CODE_DIR, NotFoundError, log
+from .db import JobDB, ARCHIVE_NAME, CODE_DIR, NotFoundError, BadJobError, log
 from datetime import datetime
 import re
 from . import state
@@ -43,6 +43,8 @@ def _get(job_name):
         return db.get(job_name)
     except NotFoundError:
         flask.abort(404, 'Job {} not found.'.format(job_name))
+    except BadJobError:
+        flask.abort(410, 'Job {} is malformed.'.format(job_name))
 
 
 def _unpad(s):


### PR DESCRIPTION
Raise an appropriate error when requesting a specific job, and do not include corrupted job in the list of "all" jobs. This should let the buildbot keep on truckin' without a mysterious 500 error when something bad happens.