### PR TITLE
buildbot: Move timeouts to configuration

### DIFF
--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -38,3 +38,9 @@ CONFIG_OPTIONS = [
 
 # The number of (recent) lines of the log to show on job pages.
 LOG_PREVIEW_LINES = 5
+
+# The timeouts for running the initial compilation step and for running
+# the synthesis step (or running an opaque Makefile), the latter of
+# which has to be really long because synthesis is so slow.
+COMPILE_TIMEOUT = 120
+SYNTHESIS_TIMEOUT = 3000

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -205,11 +205,9 @@ def stage_make(db, config):
         if task['config'].get('estimate'):
             sdsflags += '-perf-est-hw-only'
 
-        # NOTE(rachit): The timeout here is really high because
-        # synthesis takes a real long time.
         task.run(
             prefix + ['make', 'SDSFLAGS={}'.format(sdsflags)],
-            timeout=3600,
+            timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,
         )
 
@@ -301,7 +299,7 @@ def stage_hls(db, config):
                 '-c',
                 hw_c, '-o', hw_o,
             ],
-            timeout=120,
+            timeout=config["COMPILE_TIMEOUT"],
             cwd=CODE_DIR,
         )
 
@@ -322,7 +320,7 @@ def stage_hls(db, config):
             _sds_cmd(prefix, hw_basename, hw_c) + [
                 xflags, hw_o, HOST_O, '-o', EXECUTABLE,
             ],
-            timeout=3000,
+            timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,
         )
 


### PR DESCRIPTION
[Based on #161, so the diff will look better after that's merged.]

The timeouts for compilation and synthesis are now in the buildbot's configuration, so they don't require editing hard-coded numbers to adjust anymore.