### PR TITLE
Expose hw target and sdsflags as curl options on buildbot

### DIFF
--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -47,3 +47,6 @@ LOG_PREVIEW_LINES = 32
 # which has to be really long because synthesis is so slow.
 COMPILE_TIMEOUT = 120
 SYNTHESIS_TIMEOUT = 3000
+
+# Default Xilinx target platform.
+DEFAULT_PLATFORM = 'zed'

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -30,11 +30,13 @@ TEXT_EXTENSIONS = [
 ]
 
 # Configuration options allowed during job creation.
-CONFIG_OPTIONS = [
-    'skipseashell',
-    'estimate',
-    'make',
-]
+CONFIG_OPTIONS = {
+    'skipseashell': 'bool',
+    'estimate': 'bool',
+    'make': 'bool',
+    'sdsflags': 'str',
+    'platform': 'str',
+}
 
 # The number of (recent) lines of the log to show on job pages.
 LOG_PREVIEW_LINES = 32

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -29,13 +29,14 @@ TEXT_EXTENSIONS = [
     'dat',
 ]
 
-# Configuration options allowed during job creation.
+# Configuration options allowed during job creation. Each option has a
+# conversion function (i.e., type) used to translate the request value.
 CONFIG_OPTIONS = {
-    'skipseashell': 'bool',
-    'estimate': 'bool',
-    'make': 'bool',
-    'sdsflags': 'str',
-    'platform': 'str',
+    'skipseashell': bool,
+    'estimate': bool,
+    'make': bool,
+    'sdsflags': str,
+    'platform': str,
 }
 
 # The number of (recent) lines of the log to show on job pages.

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -103,7 +103,7 @@ def get_config(values):
     """
     config = {}
     for key, typ in app.config['CONFIG_OPTIONS'].items():
-        config[key] = typ(values.get(key))
+        config[key] = typ(values.get(key, ''))
     return config
 
 

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -102,8 +102,13 @@ def get_config(values):
     form values.
     """
     config = {}
-    for key in app.config['CONFIG_OPTIONS']:
-        config[key] = bool(values.get(key))
+    for key, typ in app.config['CONFIG_OPTIONS']:
+        v = values.get(key)
+        if typ == 'bool':
+            v = bool(v)
+        elif typ == 'str':
+            v = str(v)
+        config[key] = v
     return config
 
 

--- a/buildbot/buildbot/server.py
+++ b/buildbot/buildbot/server.py
@@ -102,13 +102,8 @@ def get_config(values):
     form values.
     """
     config = {}
-    for key, typ in app.config['CONFIG_OPTIONS']:
-        v = values.get(key)
-        if typ == 'bool':
-            v = bool(v)
-        elif typ == 'str':
-            v = str(v)
-        config[key] = v
+    for key, typ in app.config['CONFIG_OPTIONS'].items():
+        config[key] = typ(values.get(key))
     return config
 
 

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -11,7 +11,6 @@ from . import state
 SEASHELL_EXT = '.fuse'
 C_EXT = '.cpp'
 OBJ_EXT = '.o'
-DEFAULT_PLATFORM = 'zed'
 C_MAIN = 'main.cpp'  # Currently, the host code *must* be named this.
 HOST_O = 'main.o'  # The .o file for host code.
 EXECUTABLE = 'sdsoc'
@@ -201,7 +200,8 @@ def stage_make(db, config):
     prefix = config["HLS_COMMAND_PREFIX"]
     with work(db, state.MAKE, state.MAKE_PROGRESS, state.HLS_FINISH) as task:
         sdsflags = task['config'].get('sdsflags') or ''
-        platform = task['config'].get('platform') or DEFAULT_PLATFORM
+        platform = task['config'].get('platform') or \
+            config['DEFAULT_PLATFORM']
 
         # If estimation is requested, pass in estimation flag
         if task['config'].get('estimate'):
@@ -295,7 +295,8 @@ def stage_hls(db, config):
         hw_basename, hw_c, hw_o = _hw_filenames(task)
 
         xflags = task['config'].get('sdsflags') or ''
-        platform = task['config'].get('platform') or DEFAULT_PLATFORM
+        platform = task['config'].get('platform') or \
+            config['DEFAULT_PLATFORM']
 
         # Run Xilinx SDSoC compiler for hardware functions.
         task.run(

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -84,7 +84,6 @@ class JobTask:
         log_filename = self.db._log_path(self.job['name'])
         with open(log_filename, 'ab') as f:
             try:
-                print(cmd, kwargs)
                 return subprocess.run(
                     cmd,
                     check=True,

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -208,7 +208,11 @@ def stage_make(db, config):
             sdsflags += ' -perf-est-hw-only'
 
         task.run(
-            prefix + ['make', 'SDSFLAGS={} PLATFORM={}'.format(sdsflags, platform)],
+            prefix + [
+                'make',
+                'SDSFLAGS={}'.format(sdsflags),
+                'PLATFORM={}'.format(platform),
+            ],
             timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,
         )
@@ -294,7 +298,7 @@ def stage_hls(db, config):
     with work(db, state.COMPILE_FINISH, state.HLS, state.HLS_FINISH) as task:
         hw_basename, hw_c, hw_o = _hw_filenames(task)
 
-        xflags = task['config'].get('sdsflags') or ''
+        xflags = shlex.split(task['config'].get('sdsflags') or '')
         platform = task['config'].get('platform') or \
             config['DEFAULT_PLATFORM']
 
@@ -318,12 +322,12 @@ def stage_hls(db, config):
         )
 
         if task['config'].get('estimate'):
-            xflags += ' -perf-est-hw-only'
+            xflags += ['-perf-est-hw-only']
 
         # Run Xilinx SDSoC compiler for created objects.
         task.run(
-            _sds_cmd(prefix, hw_basename, hw_c) + [
-                xflags, hw_o, HOST_O, '-o', EXECUTABLE,
+            _sds_cmd(prefix, hw_basename, hw_c) + xflags + [
+                hw_o, HOST_O, '-o', EXECUTABLE,
             ],
             timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -304,7 +304,7 @@ def stage_hls(db, config):
 
         # Run Xilinx SDSoC compiler for hardware functions.
         task.run(
-            _sds_cmd(prefix, hw_basename, hw_c, platform) + [
+            _sds_cmd(prefix, hw_basename, hw_c, platform) + xflags + [
                 '-c',
                 hw_c, '-o', hw_o,
             ],
@@ -314,7 +314,7 @@ def stage_hls(db, config):
 
         # Run the Xilinx SDSoC compiler for host function.
         task.run(
-            _sds_cmd(prefix, hw_basename, hw_c, platform) + [
+            _sds_cmd(prefix, hw_basename, hw_c, platform) + xflags + [
                 '-c',
                 C_MAIN, '-o', HOST_O,
             ],


### PR DESCRIPTION
As I was writing this, I realized that we can just set the platform and other flags in the Makefile itself. @sa2257 can just use the Makefiles while this is being tested (probably not today, I'm sick)