### PR TITLE
buildbot: Provide executable name as TARGET argument to Makefile

### DIFF
--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -39,6 +39,9 @@ CONFIG_OPTIONS = {
     'platform': str,
 }
 
+# The name to use for compiled executables.
+EXECUTABLE_NAME = 'sdsoc'
+
 # The number of (recent) lines of the log to show on job pages.
 LOG_PREVIEW_LINES = 32
 

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -226,6 +226,7 @@ def stage_make(db, config):
                 'make',
                 'ESTIMATE={}'.format(task['estimate']),
                 'PLATFORM={}'.format(task['platform']),
+                'TARGET={}'.format(config['EXECUTABLE_NAME']),
             ],
             timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -13,7 +13,6 @@ C_EXT = '.cpp'
 OBJ_EXT = '.o'
 C_MAIN = 'main.cpp'  # Currently, the host code *must* be named this.
 HOST_O = 'main.o'  # The .o file for host code.
-EXECUTABLE = 'sdsoc'
 
 # For executing on a Xilinx Zynq board.
 ZYNQ_SSH_PREFIX = ['sshpass', '-p', 'root']  # Provide Zynq SSH password.
@@ -337,7 +336,7 @@ def stage_hls(db, config):
         # Run Xilinx SDSoC compiler for created objects.
         task.run(
             _sds_cmd(prefix, hw_basename, hw_c, task['platform']) + flags + [
-                hw_o, HOST_O, '-o', EXECUTABLE,
+                hw_o, HOST_O, '-o', config['EXECUTABLE_NAME'],
             ],
             timeout=config["SYNTHESIS_TIMEOUT"],
             cwd=CODE_DIR,
@@ -379,7 +378,8 @@ def stage_fpga_execute(db, config):
 
         # Run the FPGA program and collect results
         task.run(
-            ZYNQ_SSH_PREFIX + ['ssh', ZYNQ_HOST, '/mnt/' + EXECUTABLE],
+            ZYNQ_SSH_PREFIX + ['ssh', ZYNQ_HOST, '/mnt/' +
+                               config['EXECUTABLE_NAME']],
             timeout=120
         )
 


### PR DESCRIPTION
As discussed in #166.