### PR TITLE
Visualizing array accesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _test
 
 ## Object files
 *.o
+
+compiled/
+*~

--- a/docs/array-access-visualizer.md
+++ b/docs/array-access-visualizer.md
@@ -1,0 +1,67 @@
+---
+id: access-visualizer
+title: Array Access Visualizer
+---
+
+We have written a small library in Racket to provide visualization facilities
+for array accesses. This tool can be used while developing Fuse programs
+that make use of complicated array access patterns and views.
+
+The library defines the wrapper `let/matrix` which allows defining matrices
+and defines C-like array access notation for those arrays. The `let/matrix`
+context also defines `---` that corresponds to the sequencing operator in
+Fuse.
+
+To play with examples, open `tools/array-access-visualizer/examples.rkt`
+in [DrRacket][drracket] and click run. This will generate three sequences of
+images that corresponds to the two examples.
+
+For the first example, we have:
+
+```
+(let/matrix ([A 2 4])
+  (A[0][1])
+  (---)
+  (A[1][2]))
+```
+
+The first sequence in `let/matrix` defines a matrix `A` with dimensions `2` and
+`4`. The remaining expressions in `let/matrix` simply access the array. The
+`(---)` tells the visualizer that the two access are sequential, not parallel.
+Try removing it to see the visualization generated.
+
+The second example is a bit more interesting:
+
+```
+(let/matrix ([A 2 4]
+             [B 1 8])
+ (for ([i (in-range 1)]
+       [j (in-range 4)])
+   (A[i][j])
+   (A[(+ i 1)][j])
+   (B[0][j])))
+```
+
+Here we define two matrices `A` and `B` and iterate over them using the `for`
+construct. While we can use any arbitrary iterator (like recursive functions or
+`while` loops), the `for` form is special in that it implicitly adds a `(---)`
+at the end of each iteration. This means that for each iteration, the `A[i][j]`
+and `A[(+ i 1)][j]` accesses are in parallel but the cross iteration accesses
+are sequential.
+
+Also note that this `let/matrix` generates *two* images. In general, for
+`n` matrix declarations, the visualizer will generate `n` sequences of array
+accesses.
+
+The values produced by `let/matrix` are first class racket lists that can be
+manipulated like other values:
+
+```
+(define-value (A-access B-access)
+  (let/matrix ([A 2 2]
+               [B 2 2])
+    (A[1][1])
+    (B[1][1])))
+
+(map (lambda (img) (scale img 3.5)) A-access)
+```

--- a/docs/text-editors.md
+++ b/docs/text-editors.md
@@ -12,7 +12,7 @@ We have a syntax highlighting plugin called `vim-fuse`.
 - If you're using [Pathogen](https://github.com/tpope/vim-pathogen), install
   `vim-fuse` by running this in the `seashell/` directory:
     - `cp -r tools/vim ~/.vim/bundle/vim-fuse`
-    
+
 ## Emacs
 
 We have a mode that provides syntax highlighting and indentation.

--- a/tools/array-access-visualizer/examples.rkt
+++ b/tools/array-access-visualizer/examples.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+(require "let-matrix.rkt")
+
+;; "tests"
+(let/matrix
+ ([A 2 4])
+ (A[0][1])
+ (---)
+ (A[1][2]))
+
+(let/matrix
+ ([A 2 4]
+  [B 1 8])
+ (for ([i (in-range 1)]
+       [j (in-range 4)])
+   (A[i][j])
+   (A[(+ i 1)][j])
+   (B[0][j])))

--- a/tools/array-access-visualizer/let-matrix.rkt
+++ b/tools/array-access-visualizer/let-matrix.rkt
@@ -1,0 +1,69 @@
+#lang racket/base
+
+(require (for-syntax racket/base)
+         racket/syntax
+         racket/stxparam
+         racket/contract
+         racket/set
+         "matrix-visualizer.rkt")
+
+;; Defines `get` that adds the given index to the current set of accesses
+;; made by the array.
+(define/contract (get arr idxs)
+  (-> (listof (set/c #:kind 'mutable (listof number?))) (non-empty-listof number?) void)
+  (set-add! (car arr) idxs))
+
+;; Add a new sequence to the array access.
+(define-syntax-rule (seq-arr arr ...)
+  (begin
+    (set! arr (cons (mutable-set) arr))
+    ...))
+
+;; Turn instances of the syntax (id[i0][i1]...) to (get id i0 i1 ...).
+;; Also defines id to be an error anywhere else.
+;; (... ...) is used to escape the level two ... in the internal macro.
+(define-syntax-rule (define-accessor-syntax id id-access)
+  (define-syntax (id stx)
+    (syntax-case stx ()
+      [(id (e1) (e) (... ...))
+       #'(get id-access (list e1 e (... ...)))]
+      [id (raise-syntax-error #f "can only used as an array access (arr[i][j]) and requires at least one accessor." stx)])))
+
+;; Define (---) to be an error outside let/matrix contexts
+(define-syntax-parameter ---
+  (lambda (stx)
+    (raise-syntax-error #f "can only be used inside let/matrix" stx)))
+
+;; Define wrapper context that can tracks accesses into matrices and
+;; generates a visualization for them. The matrice identifiers bound by the
+;; context can only be used with the get syntax and are defined to be an
+;; error everywhere else (TODO).
+(define-syntax (let/matrix stx)
+  (syntax-case stx ()
+    [(_ [(id rows cols) ...] body ...)
+     ;; Generate temporary names for structures that keep track of array accesses.
+     (with-syntax ([(id-access ...) (generate-temporaries #'(id ...))])
+       #'(begin
+           ;; Define structures to keep track to accesses into matrices
+           (define id-access (list (mutable-set))) ...
+           ;; Define --- operator for this let/matrix context
+           (syntax-parameterize ([--- (syntax-rules () [(_) (seq-arr id-access ...)])])
+             ;; Define syntactic sugar M[i][j]... for array accesses
+             (define-accessor-syntax id id-access) ...
+             ;; Run the body
+             body ...
+             ;; Generate visualization for all accesses
+             (values (matrix-seq rows cols (reverse id-access)) ...))))]))
+
+;; Wrapper around for* that terminates each execution of the body with
+;; a ---.
+(define-syntax-rule (for ([id init] ...) body ...)
+  (for* ([id init] ...)
+    body
+    ...
+    (---)))
+
+(provide let/matrix
+         for
+         ---
+         (all-from-out "matrix-visualizer.rkt"))

--- a/tools/array-access-visualizer/let-matrix.rkt
+++ b/tools/array-access-visualizer/let-matrix.rkt
@@ -43,9 +43,8 @@
     [(_ [(id rows cols) ...] body ...)
      ;; Generate temporary names for structures that keep track of array accesses.
      (with-syntax ([(id-access ...) (generate-temporaries #'(id ...))])
-       #'(begin
-           ;; Define structures to keep track to accesses into matrices
-           (define id-access (list (mutable-set))) ...
+       ;; Define structures to keep track to accesses into matrices
+       #'(let ([id-access (list (mutable-set))] ...)
            ;; Define --- operator for this let/matrix context
            (syntax-parameterize ([--- (syntax-rules () [(_) (seq-arr id-access ...)])])
              ;; Define syntactic sugar M[i][j]... for array accesses

--- a/tools/array-access-visualizer/matrix-visualizer.rkt
+++ b/tools/array-access-visualizer/matrix-visualizer.rkt
@@ -1,0 +1,44 @@
+#lang racket/base
+
+(require racket/set)
+(require pict)
+
+;; Define a sickly orange color for visualizing array accesses.
+(define creamsicle (list 255 153 83))
+
+;; Define what a bare array element looks like
+(define elem-size 12)
+(define arr-elem
+  (rectangle elem-size elem-size))
+
+;; Define what a marking for an array element looks like
+(define marking
+  (let ([small-elem (- elem-size 2)])
+    (colorize (rectangle small-elem small-elem) creamsicle)))
+
+;; Marks the given element
+(define (mark-elem elem)
+  (cc-superimpose elem marking))
+
+;; Two dimensional array with dimensions [[rows]] and [[cols]] and
+;; mark element in the list [[marks]].
+(define (marked-matrix rows cols marks)
+  (for/fold ([row-canvas (blank 0)])
+            ([cur-row (in-range rows)])
+    (vc-append
+     row-canvas
+     (for/fold ([col-canvas (blank 0)])
+               ([cur-col (in-range cols)])
+       (hc-append
+        col-canvas
+        (if (set-member? marks (list cur-row cur-col))
+            (mark-elem arr-elem)
+            arr-elem))))))
+
+;; Generate a sequence of [[marked-matrix]] using the given paramter
+;; [[seq]] which is a list of sets.
+(define (matrix-seq row col seq)
+  (map
+   (lambda (marks) (marked-matrix row col marks)) seq))
+
+(provide matrix-seq)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,6 +5,9 @@
     "previous": "Previous",
     "tagline": "A typed programming language for safe high-level synthesis",
     "docs": {
+      "access-visualizer": {
+        "title": "Array Access Visualizer"
+      },
       "binders": {
         "title": "Variable Binders"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,8 @@
       "cpp-runnable"
     ],
     "Tools": [
-      "text-editors"
+      "text-editors",
+      "access-visualizer"
     ],
     "Development": [
       "testing"


### PR DESCRIPTION
- Adds a racket library that can visualize array accesses
- Documentation about the library.

@tedbauer can use this when doing the fuse-rewrites to see what kinds of iteration patterns machsuite apps use.