### PR TITLE
buildbot: Change directory to /mnt to run executable

### DIFF
--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -17,6 +17,7 @@ HOST_O = 'main.o'  # The .o file for host code.
 # For executing on a Xilinx Zynq board.
 ZYNQ_SSH_PREFIX = ['sshpass', '-p', 'root']  # Provide Zynq SSH password.
 ZYNQ_HOST = 'zb1'
+ZYNQ_DEST_DIR = '/mnt'
 ZYNQ_REBOOT_DELAY = 40
 
 
@@ -364,7 +365,7 @@ def stage_fpga_execute(db, config):
         # Zynq board.
         bin_dir = os.path.join(task.code_dir, 'sd_card')
         bin_files = [os.path.join(bin_dir, f) for f in os.listdir(bin_dir)]
-        dest = ZYNQ_HOST + ':/mnt'
+        dest = '{}:{}'.format(ZYNQ_HOST, ZYNQ_DEST_DIR)
         task.run(
             ZYNQ_SSH_PREFIX + ['scp', '-r'] + bin_files + [dest],
             timeout=1200
@@ -381,7 +382,7 @@ def stage_fpga_execute(db, config):
         task.run(
             ZYNQ_SSH_PREFIX + [
                 'ssh', ZYNQ_HOST,
-                'cd /mnt ; ./{}'.format(config['EXECUTABLE_NAME']),
+                'cd {}; ./{}'.format(ZYNQ_DEST_DIR, config['EXECUTABLE_NAME']),
             ],
             timeout=120
         )

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -379,8 +379,10 @@ def stage_fpga_execute(db, config):
 
         # Run the FPGA program and collect results
         task.run(
-            ZYNQ_SSH_PREFIX + ['ssh', ZYNQ_HOST, '/mnt/' +
-                               config['EXECUTABLE_NAME']],
+            ZYNQ_SSH_PREFIX + [
+                'ssh', ZYNQ_HOST,
+                'cd /mnt ; ./{}'.format(config['EXECUTABLE_NAME']),
+            ],
             timeout=120
         )
 


### PR DESCRIPTION
As #197 describes, when buildbot executes the compiled executable on the ZedBoard, we want the cwd to be the directory where the executable lives (i.e., `/mnt`). This way, the executable can look for its data files—which also live there—with relative paths.