### PR TITLE
Parallel and Sequential composition

### DIFF
--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -580,7 +580,7 @@ object TypeChecker {
         checkC(c1)(newScope)
       }
       val env2 = checkC(c2)(env ++ binds)
-      env1 merge env2
+      env2 merge env1
     }
     case CExpr(e) => checkE(e)._2
     case CEmpty => env

--- a/src/main/scala/TypeCheck.scala
+++ b/src/main/scala/TypeCheck.scala
@@ -576,10 +576,11 @@ object TypeChecker {
       case t => throw UnexpectedType(cmd.pos, "split", "array", t)
     }
     case CSeq(c1, c2) => {
-      val (_, binds) = env.withScope(1) { newScope =>
+      val (env1, binds) = env.withScope(1) { newScope =>
         checkC(c1)(newScope)
       }
-      checkC(c2)(env ++ binds)
+      val env2 = checkC(c2)(env ++ binds)
+      env1 merge env2
     }
     case CExpr(e) => checkE(e)._2
     case CEmpty => env

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -376,6 +376,24 @@ class TypeCheckerSpec extends FunSpec {
   }
 
   describe("Sequential composition") {
+    it("total resources consumed is union of all resources consumed") {
+      assertThrows[AlreadyConsumed] {
+        typeCheck("""
+          decl a: bit<32>[8];
+          decl b: bit<32>[8];
+          decl c: bit<32>[8];
+          {
+            c[0] := 1
+            ---
+            b[0] := 1;
+            ---
+            a[0] := 1;
+          }
+          b[0] := 1
+          """ )
+      }
+    }
+
     it("doesnt refresh resources globally when composed with parallel composition") {
       assertThrows[AlreadyWrite] {
         typeCheck("""


### PR DESCRIPTION
Currently, this program typechecks:
```
{
  b[0] := 1;
  ---
  a[0] := 1;
}
b[0] := 1
```

Intuitively, the hardware generated says that the big block executed in parallel with the final write. Since a parallel composed block has no guarantees about the schedule for the elements, the two writes to `b` might conflict.

This commit makes it so that each expression in a sequential composition is checked with the same initial environment but the total resources consumed by the sequential composition is the union of all resources consumed.