### PR TITLE
Add `ap_int` preamble to generated Vivado code

### DIFF
--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -8,6 +8,13 @@ import Configuration._
 import CompilerError._
 
 private class VivadoBackend extends CppLike {
+  val CppPreamble: Doc = """
+    |// Avoid using `ap_int` in "software" compilation.
+    |#ifdef __SDSVHLS__
+    |#include "ap_int.h"
+    |template <int N> using ap_int = int;
+    |#endif
+  """.stripMargin.strip
 
   def unroll(n: Int): Doc = n match {
     case 1 => emptyDoc
@@ -60,6 +67,7 @@ private class VivadoBackend extends CppLike {
 
   def emitProg(p: Prog, c: Config): String = {
     val layout =
+      CppPreamble <@>
       vsep(p.includes.map(emitInclude)) <@>
       vsep(p.defs.map(emitDef)) <@>
       emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -12,6 +12,7 @@ private class VivadoBackend extends CppLike {
     |// Avoid using `ap_int` in "software" compilation.
     |#ifdef __SDSVHLS__
     |#include "ap_int.h"
+    |#else
     |template <int N> using ap_int = int;
     |#endif
   """.stripMargin.strip

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -15,7 +15,7 @@ private class VivadoBackend extends CppLike {
     |#else
     |template <int N> using ap_int = int;
     |#endif
-  """.stripMargin.strip
+  """.stripMargin.trim
 
   def unroll(n: Int): Doc = n match {
     case 1 => emptyDoc


### PR DESCRIPTION
On the topic of #211, this adds a short preamble to the Vivado backend that disables `ap_int` when compiling with a "normal" (non-HLS) compiler. For now, software compilation just uses `int` instead.

This is option "1a" in #211.