### PR TITLE
Evaluation hack: decorations for inserting #pragmas into generated source

### DIFF
--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -268,11 +268,16 @@ private class FuseParser extends RegexParsers with PackratParsers {
     }
   }
 
+  // Top-level decorations (for the kernel function).
+  lazy val decor: P[String] = {
+    "decor" ~> stringVal
+  }
+
   // Prog
   lazy val prog: P[Prog] = positioned {
-    include.* ~ defs.* ~ decl.* ~ cmd.? ^^ {
-      case incls ~ fns ~ decls ~ cmd =>
-        Prog(incls, fns, decls, cmd.getOrElse(CEmpty))
+    include.* ~ defs.* ~ decor.* ~ decl.* ~ cmd.? ^^ {
+      case incls ~ fns ~ decors ~ decls ~ cmd =>
+        Prog(incls, fns, decors, decls, cmd.getOrElse(CEmpty))
     }
   }
 

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -221,6 +221,7 @@ private class FuseParser extends RegexParsers with PackratParsers {
     cfor |
     conditional |
     "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) }
+    "decor" ~> stringVal ^^ { case value => CDecorate(value) }
   }
 
   lazy val parCmd: P[Command] = positioned {

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -221,7 +221,7 @@ private class FuseParser extends RegexParsers with PackratParsers {
     cfor |
     conditional |
     "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) } |
-    "decor" ~> stringVal ^^ { case value => CDecorate(value) }
+    decor
   }
 
   lazy val parCmd: P[Command] = positioned {
@@ -269,8 +269,8 @@ private class FuseParser extends RegexParsers with PackratParsers {
   }
 
   // Top-level decorations (for the kernel function).
-  lazy val decor: P[String] = {
-    "decor" ~> stringVal
+  lazy val decor: P[CDecorate] = {
+    "decor" ~> stringVal ^^ { case value => CDecorate(value) }
   }
 
   // Prog

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -220,7 +220,7 @@ private class FuseParser extends RegexParsers with PackratParsers {
     block |
     cfor |
     conditional |
-    "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) }
+    "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) } |
     "decor" ~> stringVal ^^ { case value => CDecorate(value) }
   }
 

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -113,6 +113,7 @@ object Cpp {
         "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
       case f:CFor => emitFor(f)
       case CWhile(cond, body) => "while" <> parens(cond) <+> scope(body)
+      case CDecorate(value) => value
       case CUpdate(lhs, rhs) => lhs <+> "=" <+> rhs <> semi
       case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi
       case CExpr(e) => e <> semi

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -71,7 +71,7 @@ private class VivadoBackend extends CppLike {
       CppPreamble <@>
       vsep(p.includes.map(emitInclude)) <@>
       vsep(p.defs.map(emitDef)) <@>
-      vsep(p.decors.map(text)) <@>
+      vsep(p.decors.map(d => text(d.value))) <@>
       emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))
 
     super.pretty(layout).layout

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -71,6 +71,7 @@ private class VivadoBackend extends CppLike {
       CppPreamble <@>
       vsep(p.includes.map(emitInclude)) <@>
       vsep(p.defs.map(emitDef)) <@>
+      vsep(p.decors.map(text)) <@>
       emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))
 
     super.pretty(layout).layout

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -193,6 +193,7 @@ object Syntax {
   case class CIf(cond: Expr, cons: Command, alt: Command) extends Command
   case class CFor(range: CRange, par: Command, combine: Command) extends Command
   case class CWhile(cond: Expr, body: Command) extends Command
+  case class CDecorate(value: String) extends Command
   case class CUpdate(lhs: Expr, rhs: Expr) extends Command {
     if (lhs.isLVal == false) throw UnexpectedLVal(lhs, "assignment")
   }

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -225,7 +225,7 @@ object Syntax {
   case class Prog(
     includes: List[Include],
     defs: List[Definition],
-    decors: List[String],
+    decors: List[CDecorate],
     decls: List[Decl],
     cmd: Command) extends Positional
 

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -225,6 +225,7 @@ object Syntax {
   case class Prog(
     includes: List[Include],
     defs: List[Definition],
+    decors: List[String],
     decls: List[Decl],
     cmd: Command) extends Positional
 

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -89,6 +89,7 @@ object BoundsChecker {
     case CIf(cond, tbranch, fbranch) => checkE(cond) ; checkC(tbranch) ; checkC(fbranch)
     case CFor(_, par, combine) => checkC(par) ; checkC(combine)
     case CWhile(cond, body) => checkE(cond) ; checkC(body)
+    case CDecorate(_) => ()
     case CUpdate(lhs, rhs) => checkE(lhs) ; checkE(rhs)
     case CReduce(_, l, r) => checkE(l) ; checkE(r)
     case CExpr(e) => checkE(e)

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -89,7 +89,7 @@ object BoundsChecker {
     case CIf(cond, tbranch, fbranch) => checkE(cond) ; checkC(tbranch) ; checkC(fbranch)
     case CFor(_, par, combine) => checkC(par) ; checkC(combine)
     case CWhile(cond, body) => checkE(cond) ; checkC(body)
-    case CDecorate(_) => ()
+    case _:CDecorate => ()
     case CUpdate(lhs, rhs) => checkE(lhs) ; checkE(rhs)
     case CReduce(_, l, r) => checkE(l) ; checkE(r)
     case CExpr(e) => checkE(e)

--- a/src/main/scala/passes/CapabilityChecker.scala
+++ b/src/main/scala/passes/CapabilityChecker.scala
@@ -19,7 +19,7 @@ object CapabilityChecker {
     type Env = CapabilityEnv
 
     def check(p: Prog): Unit = {
-      val Prog(_, defs, _, cmd) = p
+      val Prog(_, defs, _, _, cmd) = p
 
       defs.collect({ case FuncDef(_, _, bodyOpt) => bodyOpt.map(checkC(_)(emptyEnv)) })
 

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -59,7 +59,7 @@ object Checker {
     def checkLVal(e: Expr)(implicit env: Env): Env = checkE(e)
 
     def checkC(cmd: Command)(implicit env: Env): Env = cmd match {
-      case _:CSplit | _:CView | CEmpty => env
+      case _:CSplit | _:CView | CEmpty | CDecorate(_) => env
       case CPar(c1, c2) => checkCSeq(Vector(c1, c2))
       case CSeq(c1, c2) => checkCSeq(Vector(c1, c2))
       case CUpdate(lhs, rhs) => checkE(rhs)(checkLVal(lhs))

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -59,7 +59,7 @@ object Checker {
     def checkLVal(e: Expr)(implicit env: Env): Env = checkE(e)
 
     def checkC(cmd: Command)(implicit env: Env): Env = cmd match {
-      case _:CSplit | _:CView | CEmpty | CDecorate(_) => env
+      case _:CSplit | _:CView | CEmpty | _:CDecorate => env
       case CPar(c1, c2) => checkCSeq(Vector(c1, c2))
       case CSeq(c1, c2) => checkCSeq(Vector(c1, c2))
       case CUpdate(lhs, rhs) => checkE(rhs)(checkLVal(lhs))

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -115,6 +115,7 @@ object RewriteView {
     case cw@CWhile(_, c) => for {
       cn <- rewriteC(c)
     } yield cw.copy(body = cn)
+    case CDecorate(_) => State.unit(c)
     case CUpdate(e1, e2) => for {
       e1n <- rewriteExpr(e1)
       e2n <- rewriteExpr(e2)

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -115,7 +115,7 @@ object RewriteView {
     case cw@CWhile(_, c) => for {
       cn <- rewriteC(c)
     } yield cw.copy(body = cn)
-    case CDecorate(_) => State.unit(c)
+    case _:CDecorate => State.unit(c)
     case CUpdate(e1, e2) => for {
       e1n <- rewriteExpr(e1)
       e2n <- rewriteExpr(e2)

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -586,5 +586,6 @@ object TypeChecker {
     }
     case CExpr(e) => checkE(e)._2
     case CEmpty => env
+    case CDecorate(_) => env
   }
 }

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -79,7 +79,7 @@ object TypeChecker {
    * (`checkC`).
    */
   def typeCheck(p: Prog) = {
-    val Prog(includes, defs, decls, cmd) = p
+    val Prog(includes, defs, _, decls, cmd) = p
 
     val allDefs = includes.flatMap(_.defs) ++ defs
     val topFunc = FuncDef(Id(""), decls, Some(cmd))

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -586,6 +586,6 @@ object TypeChecker {
     }
     case CExpr(e) => checkE(e)._2
     case CEmpty => env
-    case CDecorate(_) => env
+    case _:CDecorate => env
   }
 }


### PR DESCRIPTION
OK. I feel the need to apologize for how hacky this solution is before I even start explaining it.

It's a huge hack and I'm sorry.

There we have it.

---

As per #211 (items 2 and 3), this adds a new `decor` (i.e., decoration) command, whose purpose is to insert arbitrary strings that are then inserted in to the generated source code. They have no semantics. You do this:

```
decor "#pragma SDS data copy(m1[0:row_size][0:col_size])"
```

and it inserts that `#pragma` directly into the generated C++. The idea is that, for evaluation purposes, we want to insert some pragmas into the HLS source code that we *never* intend to support as first-class language features. They're tool-specific garbage that is not interesting from a language/type system perspective; they're just annotations necessary to make the complete evaluation work. This includes the SDSoC pragmas, IMO, because they're just about host/FPGA data movement—not at all about the actual logic HLS, which is what our language (currently) targets.

These `decor` constructs can appear in two locations:

- In the normal flow of commands (they're treated as a "block" command), in which case they get inserted (on their own line) at that point in the function. This is useful for loop annotations, for example, where you want to give a loop trip count for estimation purposes.
- At the top of the file, before the `decl`s, in which case they get emitted right before the C++ kernel function. This is useful for function-level pragmas, like the SDSoC one in my example above, that annotate the function arguments.

I also considered making these a little more complicated, so they'd be backend-sensitive—that is, you'd says something like `decl vivado "#pragma ..."` to insert an annotation *only* when generating Vivado code. But I thought that was a little too much too soon.

---

Here's an example. In our `machsuite-gemm-blocked` benchmark, I changed the file to look like this:

```
decor "#pragma SDS data copy(m1[0:row_size][0:col_size])"
decor "#pragma SDS data zero_copy(prod[0:row_size][0:col_size])"

decl m1: float[4096];
decl m2: float[4096];
decl prod: float[4096];

let temp_x:float = 0.0;
let mul:float = 0.0;

let i_row:bit<32> = 0;
let k_row:bit<32> = 0;

let jj:bit<32> = 0;
while (jj < 64) {
  let kk:bit<32> = 0;
  while (kk < 64) {
    for (let i = 0..64) {
      for (let k = 0..8) {
        i_row := i * 64;
        k_row := (k + kk) * 64;
        temp_x := m1[i_row + k + kk];
        for (let j = 0..8) {
          mul := temp_x * m2[k_row + j + jj];
          let temp = prod[i_row + j + jj];
          ---
          prod[i_row + j + jj] := temp + mul;
        }
      }
    }
    kk := kk + 8;
  }
  jj := jj + 8;
}
```

With this PR, that source now compiles to this:

```c++
// Avoid using `ap_int` in "software" compilation.
#ifdef __SDSVHLS__
#include "ap_int.h"
#else
template <int N> using ap_int = int;
#endif


#pragma SDS data copy(m1[0:row_size][0:col_size])
#pragma SDS data zero_copy(prod[0:row_size][0:col_size])
void gemm(float m1[4096], float m2[4096], float prod[4096]) {
  
  float temp_x = 0.0;
  float mul = 0.0;
  ap_int<32> i_row = 0;
  ap_int<32> k_row = 0;
  ap_int<32> jj = 0;
  while((jj < 64)) {
    ap_int<32> kk = 0;
    while((kk < 64)) {
      for(int i = 0; i < 64; i++) {
        for(int k = 0; k < 8; k++) {
          i_row = (i * 64);
          k_row = ((k + kk) * 64);
          temp_x = m1[(i_row + (k + kk))];
          for(int j = 0; j < 8; j++) {
            mul = (temp_x * m2[(k_row + (j + jj))]);
            float temp = prod[(i_row + (j + jj))];
            //---
            prod[(i_row + (j + jj))] = (temp + mul);
          }
        }
      }
      kk = (kk + 8);
    }
    jj = (jj + 8);
  }
}
```

That's pretty much what we want!