### PR TITLE
Support for unsigned bit numbers

### DIFF
--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -142,7 +142,8 @@ private class FuseParser extends RegexParsers with PackratParsers {
     "float" ^^ { _ => TFloat() } |
     "double" ^^ { _ => TDouble() } |
     "bool" ^^ { _ => TBool() } |
-    "bit" ~> angular(number) ^^ { case s => TSizedInt(s) } |
+    "bit" ~> angular(number) ^^ { case s => TSizedInt(s, false) } |
+    "ubit" ~> angular(number) ^^ { case s => TSizedInt(s, true) } |
     iden ^^ { case id => TAlias(id) }
   lazy val typ: P[Type] =
     atyp ~ rep1(typIdx) ^^ { case t ~ dims => TArray(t, dims) } |

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -18,7 +18,8 @@ private class CppRunnable extends CppLike {
   def emitType(typ: Type): Doc = typ match {
     case _:TVoid => "void"
     case _:TBool => "bool"
-    case _:TIndex | _:TStaticInt | _:TSizedInt => "int"
+    case _:TIndex | _:TStaticInt => "int"
+    case TSizedInt(_, un) => if (un) "unsigned int" else "int"
     case _:TFloat => "float"
     case _:TDouble => "double"
     case TArray(typ, dims) =>

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -59,7 +59,7 @@ private class VivadoBackend extends CppLike {
     case _:TBool | _:TIndex | _:TStaticInt => "int"
     case _:TFloat => "float"
     case _:TDouble => "double"
-    case TSizedInt(s) => s"ap_int<$s>"
+    case TSizedInt(s, un) => if (un) s"ap_uint<$s>" else s"ap_int<$s>"
     case TArray(typ, _) => emitType(typ)
     case TRecType(n, _) => n
     case _:TFun => throw Impossible("Cannot emit function types")

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -48,7 +48,7 @@ object Syntax {
       case _: TBool => "bool"
       case _: TFloat => "float"
       case _: TDouble => "double"
-      case TSizedInt(l) => s"bit<$l>"
+      case TSizedInt(l, un) => s"${if (un) "u" else ""}bit<$l>"
       case TStaticInt(s) => s"static($s)"
       case TArray(t, dims) =>
         s"$t" + dims.foldLeft("")({ case (acc, (d, b)) => s"$acc[$d bank $b]" })
@@ -60,7 +60,7 @@ object Syntax {
   }
   // Types that can be upcast to Ints
   sealed trait IntType
-  case class TSizedInt(len: Int) extends Type with IntType
+  case class TSizedInt(len: Int, unsigned: Boolean) extends Type with IntType
   case class TStaticInt(v: Int) extends Type with IntType
   case class TIndex(static: (Int, Int), dynamic: (Int, Int)) extends Type with IntType {
     // Our ranges are represented as s..e with e excluded from the range.

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -29,10 +29,12 @@ object BoundsChecker {
               .zip(dims)
               .foreach({
                 case ((idx, t), (size, _)) => t.foreach({
-                  case idxt@TSizedInt(n) => if (math.pow(2, n) >= size) {
-                    scribe.warn(
-                      (s"$idxt is used for an array access. This might be out of bounds at runtime.", idx))
-                  }
+                  case idxt@TSizedInt(n, _) =>
+                    if (math.pow(2, n) >= size) {
+                      scribe.warn(
+                        (s"$idxt is used for an array access. " +
+                          "This might be out of bounds at runtime.", idx))
+                    }
                   case TStaticInt(v) => if (v >= size) throw IndexOutOfBounds(id)
                   case t@TIndex(_, _) => if (t.maxVal >= size) throw IndexOutOfBounds(id)
                   case t => throw UnexpectedType(id.pos, "array access", s"[$t]", t)
@@ -61,7 +63,7 @@ object BoundsChecker {
           .matchOrError(viewId.pos, "view", "Integer Type"){
           case idx:TIndex => fac * idx.maxVal
           case TStaticInt(v) => fac * v
-          case idx@TSizedInt(_) =>
+          case idx:TSizedInt =>
             scribe.warn(
               (s"$idx is used to create view $viewId. This could be unsafe.", idx));
             1

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1278,6 +1278,16 @@ class TypeCheckerSpec extends FunSpec {
         let z: double = x + y;
         """ )
     }
+
+    it("unsigned and signed cannot be compared") {
+      assertThrows[NoJoin] {
+        typeCheck("""
+          decl x: ubit<32>;
+          decl y: bit<32>;
+          let z = x + y;
+          """ )
+      }
+    }
   }
 
   describe("Imports") {

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1279,7 +1279,7 @@ class TypeCheckerSpec extends FunSpec {
         """ )
     }
 
-    it("unsigned and signed cannot be compared") {
+    it("unsigned and signed types are incomparable") {
       assertThrows[NoJoin] {
         typeCheck("""
           decl x: ubit<32>;


### PR DESCRIPTION
- Signed and unsigned numbers are not comparable
- By default, signed numbers are inferred.