### PR TITLE
Tiny fix: add type alias for `ap_uint` for SW compilation

### DIFF
--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -14,6 +14,7 @@ private class VivadoBackend extends CppLike {
     |#include "ap_int.h"
     |#else
     |template <int N> using ap_int = int;
+    |template <int N> using ap_uint = unsigned int;
     |#endif
   """.stripMargin.trim
 


### PR DESCRIPTION
Just a little tweak in the spirit of #211. Following new support for `ubit` in #215, this extends our typedef-like hack that allows non-HLS compilation by mapping these to `unsigned int`.