### PR TITLE
Add check for argument length mismatch in function call

### DIFF
--- a/src/main/scala/common/Errors.scala
+++ b/src/main/scala/common/Errors.scala
@@ -22,6 +22,8 @@ object Errors {
     s"Expected type $exp in $construct, received: $actual.", pos)
   case class UnexpectedSubtype(pos: Position, con: String, exp: Type, actual: Type) extends TypeError(
     s"Expected subtype of $exp in $con, received: $actual.", pos)
+  case class ArgLengthMismatch(pos: Position, expected: Int, actual: Int) extends TypeError(
+    s"Application expected $expected arguments, received $actual.", pos)
 
   // Unrolling and banking errors
   case class UnrollRangeError(pos: Position, rSize: Int, uFactor: Int) extends TypeError(

--- a/src/main/scala/common/Errors.scala
+++ b/src/main/scala/common/Errors.scala
@@ -22,8 +22,8 @@ object Errors {
     s"Expected type $exp in $construct, received: $actual.", pos)
   case class UnexpectedSubtype(pos: Position, con: String, exp: Type, actual: Type) extends TypeError(
     s"Expected subtype of $exp in $con, received: $actual.", pos)
-  case class ArgLengthMismatch(pos: Position, expected: Int, actual: Int) extends TypeError(
-    s"Application expected $expected arguments, received $actual.", pos)
+  case class ArgLengthMismatch(pos: Position, exp: Int, actual: Int) extends TypeError(
+    s"Application expected $exp arguments, received $actual.", pos)
 
   // Unrolling and banking errors
   case class UnrollRangeError(pos: Position, rSize: Int, uFactor: Int) extends TypeError(

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -260,6 +260,10 @@ object TypeChecker {
     }
     case EApp(f, args) => env(f) match {
       case TFun(argTypes) => {
+        if (argTypes.length != args.length) {
+          throw ArgLengthMismatch(expr.pos, argTypes.length, args.length)
+        }
+
         // All functions return `void`.
         TVoid() -> args.zip(argTypes).foldLeft(env)({ case (e, (arg, expectedTyp)) => {
           val (typ, e1) = checkE(arg)(e);
@@ -267,7 +271,7 @@ object TypeChecker {
             throw UnexpectedSubtype(arg.pos, "parameter", expectedTyp, typ)
           }
           // If an array id is used as a parameter, consume it completely.
-          // This works correctly with capabilties.
+          // This works correctly with capabilities.
           (typ, arg) match {
             case (ta:TArray, EVar(gadget)) => {
               val consumeList = ta.dims.map(dim => 0.until(dim._2))

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -726,6 +726,16 @@ class TypeCheckerSpec extends FunSpec {
           """ )
       }
     }
+
+    it("Require argument and parameter lengths to match") {
+      assertThrows[ArgLengthMismatch] {
+        typeCheck("""
+          def foo(a: bit<32>, b: bit<32>) {
+          }
+          foo(1);
+          """ )
+      }
+    }
   }
 
   describe("Function applications w/ externs") {


### PR DESCRIPTION
Fixes #225. It's a straightforward fix! Includes a test ensuring that this program does not type check:

```
def foo(a: bit<32>, b: bit<32>) {
}
foo(1);
```

Also a bonus spelling fix. :rocket: