### PR TITLE
Simplify the C++ preamble for Vivado backend

### DIFF
--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -9,13 +9,7 @@ import CompilerError._
 
 private class VivadoBackend extends CppLike {
   val CppPreamble: Doc = """
-    |// Avoid using `ap_int` in "software" compilation.
-    |#ifdef __SDSCC__
     |#include "ap_int.h"
-    |#else
-    |template <int N> using ap_int = int;
-    |template <int N> using ap_uint = unsigned int;
-    |#endif
   """.stripMargin.trim
 
   def unroll(n: Int): Doc = n match {


### PR DESCRIPTION
Given the hack in https://github.com/cucapra/fuse-benchmarks/pull/109, we will have a drop-in replacement for this header in software, so we won't need the #ifdef in generated code.