### PR TITLE
Generate the `#pragma HLS interface` annotation for Vivado HLS

### DIFF
--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -60,9 +60,10 @@ object Cpp {
     /**
      * Used to emit function headers. All C++ backends will convert the function
      * bodies in the same way but might require different pragrams for arguments
-     * or setup code.
+     * or setup code. `entry` distinguishes the top-level entry point
+     * function.
      */
-    def emitFuncHeader(func: FuncDef): Doc
+    def emitFuncHeader(func: FuncDef, entry: Boolean = false): Doc
 
     implicit def IdToString(id: Id): Doc = value(id.v)
 
@@ -127,11 +128,11 @@ object Cpp {
       case _ => emitType(typ) <+> id
     }
 
-    def emitFunc: FuncDef => Doc = { case func@FuncDef(id, args, bodyOpt) =>
+    def emitFunc(func: FuncDef, entry: Boolean = false): Doc = func match { case func@FuncDef(id, args, bodyOpt) =>
       val as = hsep(args.map(decl => emitDecl(decl.id, decl.typ)), comma)
       // If body is not defined, this is an extern. Elide the definition.
       bodyOpt.map(body => "void" <+> id <> parens(as) <+> scope {
-        emitFuncHeader(func) <@>
+        emitFuncHeader(func, entry) <@>
         body
       }).getOrElse(emptyDoc)
     }

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -42,7 +42,7 @@ private class CppRunnable extends CppLike {
       }
     }
 
-  def emitFuncHeader(func: FuncDef) = emptyDoc
+  def emitFuncHeader(func: FuncDef, entry: Boolean = false) = emptyDoc
 
   /**
    * Emit code to parse the value for declaration `d`. Assumes that the
@@ -141,7 +141,7 @@ private class CppRunnable extends CppLike {
 private class CppRunnableHeader extends CppRunnable {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc = { case FuncDef(id, args, _) =>
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, _) =>
     val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
     "void" <+> id <> parens(as) <> semi
   }
@@ -152,7 +152,7 @@ private class CppRunnableHeader extends CppRunnable {
     val declarations =
       vsep(includes.map(emitInclude)) <@>
       vsep (p.defs.map(emitDef)) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, None))
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, None), true)
 
     super.pretty(declarations).layout
   }

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -39,7 +39,7 @@ private class VivadoBackend extends CppLike {
        else emptyDoc)
     }
 
-  def emitFuncHeader(func: FuncDef): Doc = {
+  def emitFuncHeader(func: FuncDef, entry: Boolean = false): Doc = {
     vsep(bankPragmas(func.args))
   }
 
@@ -68,7 +68,7 @@ private class VivadoBackend extends CppLike {
       vsep(p.includes.map(emitInclude)) <@>
       vsep(p.defs.map(emitDef)) <@>
       vsep(p.decors.map(d => text(d.value))) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)))
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)), true)
 
     super.pretty(layout).layout
   }
@@ -78,7 +78,7 @@ private class VivadoBackend extends CppLike {
 private class VivadoBackendHeader extends VivadoBackend {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc = { case FuncDef(id, args, _) =>
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, _) =>
     val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
     "void" <+> id <> parens(as) <> semi
   }

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -40,6 +40,9 @@ private class VivadoBackend extends CppLike {
     }
 
   def emitFuncHeader(func: FuncDef, entry: Boolean = false): Doc = {
+    (if (entry)
+      vsep(func.args.map(arg => text(s"#pragma HLS INTERFACE ap_memory port=${arg.id}")))
+     else emptyDoc) <@>
     vsep(bankPragmas(func.args))
   }
 


### PR DESCRIPTION
For a long list of reasons, we'd like to run Fuse programs _independently_ through Vivado HLS, eschewing SDSoC altogether. This additional pragma makes it possible to do so while marking the "external interface" arguments (essentially, `decl`s) as being allocated to BRAMs. Otherwise, they don't seem to get memories at all; they just turn into wires connected to the outside world.