### PR TITLE
Fix #230 by putting partitioning pragmas in the proper place

### DIFF
--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -65,6 +65,15 @@ object Cpp {
      */
     def emitFuncHeader(func: FuncDef, entry: Boolean = false): Doc
 
+    /**
+     * Generate code for a "let" binding. (Might need to be followed by
+     * pragmas.)
+     */
+    def emitLet(let: CLet): Doc =
+      emitDecl(let.id, let.typ.get) <>
+      (if (let.e.isDefined) space <> equal <+> emitExpr(let.e.get) else emptyDoc) <>
+      semi
+
     implicit def IdToString(id: Id): Doc = value(id.v)
 
     def scope(doc: Doc): Doc =
@@ -106,10 +115,7 @@ object Cpp {
     implicit def emitCmd(c: Command): Doc = c match {
       case CPar(c1, c2) => c1 <@> c2
       case CSeq(c1, c2) => c1 <@> text("//---") <@> c2
-      case CLet(id, typ, init) =>
-        emitDecl(id, typ.get) <>
-        (if (init.isDefined) space <> equal <+> emitExpr(init.get) else emptyDoc) <>
-        semi
+      case l:CLet => emitLet(l)
       case CIf(cond, cons, alt) =>
         "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
       case f:CFor => emitFor(f)

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -31,6 +31,14 @@ private class VivadoBackend extends CppLike {
     .withFilter(s => s != "")
     .map(s => value(s))
 
+  override def emitLet(let: CLet): Doc = {
+    super.emitLet(let) <@>
+    (let.typ match {
+      case Some(t) => vsep(bankPragmas(List(Decl(let.id, t))))
+      case None => emptyDoc
+    })
+  }
+
   def emitFor(cmd: CFor): Doc =
     "for" <> emitRange(cmd.range) <+> scope {
       unroll(cmd.range.u) <>
@@ -47,8 +55,7 @@ private class VivadoBackend extends CppLike {
   }
 
   def emitArrayDecl(ta: TArray, id: Id) =
-    emitType(ta.typ) <+> id <> generateDims(ta.dims) <@>
-    vsep(bankPragmas(List(Decl(id, ta))))
+    emitType(ta.typ) <+> id <> generateDims(ta.dims)
 
   def generateDims(dims: List[(Int, Int)]): Doc =
     ssep(dims.map(d => brackets(value(d._1))), emptyDoc)


### PR DESCRIPTION
Now partitioning pragmas go in the function header and `let` rather than being part of the declaration. This solves both #230 and a related problem where pragmas following `let` declarations would go before the initializer and semicolon.