### PR TITLE
Add return values to functions

### DIFF
--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -243,15 +243,21 @@ private class FuseParser extends RegexParsers with PackratParsers {
       case n ~ fs => RecordDef(n, fs.map(decl => decl.id -> decl.typ).toMap)
     }
   }
+  lazy val retTyp: P[Type] = {
+    (":" ~> typ).? ^^ {
+      case Some(t) => t
+      case None => TVoid()
+    }
+  }
   lazy val externFuncDef: P[FuncDef] = positioned {
-    "def" ~ "extern" ~> iden ~ parens(repsep(args, ",")) <~ ";" ^^ {
-      case fn ~ args  => FuncDef(fn, args, None)
+    "def" ~ "extern" ~> iden ~ parens(repsep(args, ",")) ~ retTyp <~ ";" ^^ {
+      case fn ~ args ~ ret => FuncDef(fn, args, ret, None)
     }
   }
   lazy val funcDef: P[FuncDef] = positioned {
     externFuncDef |
-    "def" ~> iden ~ parens(repsep(args, ",")) ~ block ^^ {
-      case fn ~ args ~ body => FuncDef(fn, args, Some(body))
+    "def" ~> iden ~ parens(repsep(args, ",")) ~ retTyp ~ block ^^ {
+      case fn ~ args ~ ret ~ body => FuncDef(fn, args, ret, Some(body))
     }
   }
   lazy val defs = funcDef | recordDef

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -205,6 +205,7 @@ private class FuseParser extends RegexParsers with PackratParsers {
     "let" ~> iden ~ (":" ~> typ).? ~ ("=" ~> expr).? ^^ {
       case id ~ t ~ exp => CLet(id, t, exp)
     } |
+    "return" ~> expr ^^ { case e => CReturn(e) } |
     view | splitView |
     expr ~ ":=" ~ expr ^^ { case l ~ _ ~ r => CUpdate(l, r) } |
     expr ~ rop ~ expr ^^ { case l ~ rop ~ r => CReduce(rop, l, r) } |

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -123,6 +123,7 @@ object Cpp {
       case CDecorate(value) => value
       case CUpdate(lhs, rhs) => lhs <+> "=" <+> rhs <> semi
       case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi
+      case CReturn(e) => "return" <+> e <> semi
       case CExpr(e) => e <> semi
       case CEmpty => emptyDoc
       case _:CView | _:CSplit =>

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -134,10 +134,10 @@ object Cpp {
       case _ => emitType(typ) <+> id
     }
 
-    def emitFunc(func: FuncDef, entry: Boolean = false): Doc = func match { case func@FuncDef(id, args, bodyOpt) =>
+    def emitFunc(func: FuncDef, entry: Boolean = false): Doc = func match { case func@FuncDef(id, args, ret, bodyOpt) =>
       val as = hsep(args.map(decl => emitDecl(decl.id, decl.typ)), comma)
       // If body is not defined, this is an extern. Elide the definition.
-      bodyOpt.map(body => "void" <+> id <> parens(as) <+> scope {
+      bodyOpt.map(body => emitType(ret) <+> id <> parens(as) <+> scope {
         emitFuncHeader(func, entry) <@>
         body
       }).getOrElse(emptyDoc)

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -116,7 +116,7 @@ private class CppRunnable extends CppLike {
       (startHelpers ::
       parseHelpers ::
       endHelpers ::
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd))) ::
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), Some(p.cmd))) ::
       Nil)
     }
 
@@ -141,9 +141,9 @@ private class CppRunnable extends CppLike {
 private class CppRunnableHeader extends CppRunnable {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, _) =>
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, ret, _) =>
     val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
-    "void" <+> id <> parens(as) <> semi
+    emitType(ret) <+> id <> parens(as) <> semi
   }
 
   override def emitProg(p: Prog, c: Config) = {
@@ -152,7 +152,7 @@ private class CppRunnableHeader extends CppRunnable {
     val declarations =
       vsep(includes.map(emitInclude)) <@>
       vsep (p.defs.map(emitDef)) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, None), true)
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), None), true)
 
     super.pretty(declarations).layout
   }

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -83,7 +83,7 @@ private class VivadoBackend extends CppLike {
       vsep(p.includes.map(emitInclude)) <@>
       vsep(p.defs.map(emitDef)) <@>
       vsep(p.decors.map(d => text(d.value))) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, Some(p.cmd)), true)
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), Some(p.cmd)), true)
 
     super.pretty(layout).layout
   }
@@ -93,15 +93,15 @@ private class VivadoBackend extends CppLike {
 private class VivadoBackendHeader extends VivadoBackend {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, _) =>
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, ret, _) =>
     val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
-    "void" <+> id <> parens(as) <> semi
+    emitType(ret) <+> id <> parens(as) <> semi
   }
 
   override def emitProg(p: Prog, c: Config) = {
     val declarations =
       vsep(p.includes.map(emitInclude) ++ p.defs.map(emitDef)) <@>
-      emitFunc(FuncDef(Id(c.kernelName), p.decls, None))
+      emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), None))
 
     super.pretty(declarations).layout
   }

--- a/src/main/scala/common/Errors.scala
+++ b/src/main/scala/common/Errors.scala
@@ -25,6 +25,10 @@ object Errors {
   case class ArgLengthMismatch(pos: Position, exp: Int, actual: Int) extends TypeError(
     s"Application expected $exp arguments, received $actual.", pos)
 
+  // Return statements
+  case class ReturnNotInFunc(pos: Position) extends TypeError(
+    s"Return statements are only allowed in fucntions.", pos)
+
   // Unrolling and banking errors
   case class UnrollRangeError(pos: Position, rSize: Int, uFactor: Int) extends TypeError(
     s"Cannot unroll range of size $rSize by factor $uFactor.", pos)

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -53,7 +53,7 @@ object Syntax {
       case TArray(t, dims) =>
         s"$t" + dims.foldLeft("")({ case (acc, (d, b)) => s"$acc[$d bank $b]" })
       case TIndex(s, d) => s"idx($s, $d)"
-      case TFun(args) => s"${args.mkString("->")} -> void"
+      case TFun(args, ret) => s"${args.mkString("->")} -> ${ret}"
       case TRecType(n, _) => s"$n"
       case TAlias(n) => n.toString
     }
@@ -72,7 +72,7 @@ object Syntax {
   case class TBool() extends Type
   case class TFloat() extends Type
   case class TDouble() extends Type
-  case class TFun(args: List[Type]) extends Type
+  case class TFun(args: List[Type], ret: Type) extends Type
   case class TRecType(name: Id, fields: Map[Id, Type]) extends Type
   case class TAlias(name: Id) extends Type
   case class TArray(typ: Type, dims: List[(Int, Int)]) extends Type {
@@ -171,7 +171,7 @@ object Syntax {
    * Represents function definitions. A missing function body implies that
    * this is an extern function.
    */
-  case class FuncDef(id: Id, args: List[Decl], bodyOpt: Option[Command]) extends Definition
+  case class FuncDef(id: Id, args: List[Decl], retTy: Type, bodyOpt: Option[Command]) extends Definition
   case class RecordDef(name: Id, fields: Map[Id, Type]) extends Definition {
     fields.foreach({ case (f, t) => t match {
       case _:TArray => throw ArrayInRecord(name, f, t)
@@ -205,4 +205,3 @@ object Syntax {
     }
   }
 }
-

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -163,6 +163,7 @@ object Syntax {
   case class CReduce(rop: ROp, lhs: Expr, rhs: Expr) extends Command {
     if (lhs.isLVal == false) throw UnexpectedLVal(lhs, "reduction")
   }
+  case class CReturn(exp: Expr) extends Command
   case class CExpr(exp: Expr) extends Command
   case object CEmpty extends Command
 

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -95,6 +95,7 @@ object BoundsChecker {
     case CUpdate(lhs, rhs) => checkE(lhs) ; checkE(rhs)
     case CReduce(_, l, r) => checkE(l) ; checkE(r)
     case CExpr(e) => checkE(e)
+    case CReturn(e) => checkE(e)
     case CEmpty => ()
   }
 

--- a/src/main/scala/passes/CapabilityChecker.scala
+++ b/src/main/scala/passes/CapabilityChecker.scala
@@ -21,7 +21,7 @@ object CapabilityChecker {
     def check(p: Prog): Unit = {
       val Prog(_, defs, _, _, cmd) = p
 
-      defs.collect({ case FuncDef(_, _, bodyOpt) => bodyOpt.map(checkC(_)(emptyEnv)) })
+      defs.collect({ case FuncDef(_, _, _, bodyOpt) => bodyOpt.map(checkC(_)(emptyEnv)) })
 
       checkC(cmd)(emptyEnv); ()
     }

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -41,7 +41,7 @@ object Checker {
     }
 
     def checkDef(defi: Definition)(implicit env: Env) = defi match {
-      case FuncDef(_, _, bodyOpt) => bodyOpt.map(checkC).getOrElse(env)
+      case FuncDef(_, _, _, bodyOpt) => bodyOpt.map(checkC).getOrElse(env)
       case _:RecordDef => env
     }
 

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -66,6 +66,7 @@ object Checker {
       case CReduce(_, lhs, rhs) => checkE(rhs)(checkLVal(lhs))
       case CLet(_, _, eOpt) => eOpt.map(checkE).getOrElse(env)
       case CExpr(e) => checkE(e)
+      case CReturn(e) => checkE(e)
       case CIf(cond, c1, c2) => {
         val nEnv = checkE(cond)
         val e1 = nEnv.withScope(checkC(c1)(_))

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -127,6 +127,9 @@ object RewriteView {
     case CExpr(exp) => for {
       e1n <- rewriteExpr(exp)
     } yield CExpr(e1n)
+    case CReturn(exp) => for {
+      e1n <- rewriteExpr(exp)
+    } yield CReturn(e1n)
     case CEmpty => State.unit(c)
   }
 

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -133,7 +133,7 @@ object RewriteView {
   def rewriteProg(p: Prog): Prog = {
     val emptyEnv = Map[Id, List[Expr] => Expr]()
     val fs = p.defs.map(defi => defi match {
-      case fdef@FuncDef(_, _, bOpt) => fdef.copy(bodyOpt = bOpt.map(b => rewriteC(b)(emptyEnv)._1))
+      case fdef@FuncDef(_, _, _, bOpt) => fdef.copy(bodyOpt = bOpt.map(b => rewriteC(b)(emptyEnv)._1))
       case _ => defi
     })
     val cmdn = rewriteC(p.cmd)(emptyEnv)._1

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -591,6 +591,7 @@ object TypeChecker {
       env2 merge env1
     }
     case CExpr(e) => checkE(e)._2
+    case CReturn(e) => checkE(e)._2
     case CEmpty => env
     case _:CDecorate => env
   }

--- a/src/main/scala/typechecker/TypeEnv.scala
+++ b/src/main/scala/typechecker/TypeEnv.scala
@@ -155,10 +155,10 @@ object TypeEnv {
     phyRes: ScopedMap[Id, ArrayInfo] = ScopedMap(),
     gadgetMap: ScopedMap[Id, Gadget] = ScopedMap())(implicit val res: Int) extends Environment {
 
-    /** Type defintions */
+    /** Type definitions */
     def resolveType(typ: Type): Type = typ match {
       case TAlias(n) => getType(n)
-      case TFun(args) => TFun(args.map(resolveType(_)))
+      case TFun(args, ret) => TFun(args.map(resolveType(_)), resolveType(ret))
       case arr@TArray(t, _) => arr.copy(typ = resolveType(t))
       case t => t
     }

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -679,6 +679,21 @@ class TypeCheckerSpec extends FunSpec {
       }
     }
 
+    it("allow return values") {
+      typeCheck("""
+        def foo(): bit<10> { return 5; }
+        let res: bit<10> = foo();
+       """)
+    }
+
+    it("disallow ill-typed return values") {
+      assertThrows[UnexpectedSubtype] {
+        typeCheck("""
+          def foo(): bool { return 5; }
+         """)
+      }
+    }
+
     it("allow externs to be defined") {
       typeCheck("""
         def extern bar(a: bool);


### PR DESCRIPTION
Closes #224. The syntax looks like this:

```
def add(a: bit<32>, b: bit<32>): bit<32> {
  return a + b;
}
```

Return type annotations are optional, so this remains valid syntax (and defines a function that returns void):

```
def add_and_ignore(a: bit<32>, b: bit<32>) {
  a + b;
}
```