### PR TITLE
Worst-effort pipelining

### DIFF
--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -216,7 +216,7 @@ private class FuseParser extends RegexParsers with PackratParsers {
     block |
     cfor |
     conditional |
-    "while" ~> parens(expr) ~ block ^^ { case cond ~ body => CWhile(cond, body) } |
+    "while" ~> parens(expr) ~ "pipeline".? ~ block ^^ { case cond ~ pl ~ body => CWhile(cond, pl.isDefined, body) } |
     decor
   }
 

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -159,8 +159,8 @@ private class FuseParser extends RegexParsers with PackratParsers {
     }
   }
   lazy val cfor: P[Command] = positioned {
-    "for" ~> crange ~ block ~ ("combine" ~> block).? ^^ {
-      case range ~ par ~ c => CFor(range, par, c.getOrElse(CEmpty))
+    "for" ~> crange ~ "pipeline".? ~ block ~ ("combine" ~> block).? ^^ {
+      case range ~ pl ~ par ~ c => CFor(range, pl.isDefined, par, c.getOrElse(CEmpty))
     }
   }
 

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -58,6 +58,12 @@ object Cpp {
     def emitFor(cmd: CFor): Doc
 
     /**
+     * Emit while loops.
+     */
+    def emitWhile(cmd: CWhile): Doc =
+      "while" <> parens(cmd.cond) <+> scope(cmd.body)
+
+    /**
      * Used to emit function headers. All C++ backends will convert the function
      * bodies in the same way but might require different pragrams for arguments
      * or setup code. `entry` distinguishes the top-level entry point
@@ -119,7 +125,7 @@ object Cpp {
       case CIf(cond, cons, alt) =>
         "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
       case f:CFor => emitFor(f)
-      case CWhile(cond, _, body) => "while" <> parens(cond) <+> scope(body)
+      case w:CWhile => emitWhile(w)
       case CDecorate(value) => value
       case CUpdate(lhs, rhs) => lhs <+> "=" <+> rhs <> semi
       case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -119,7 +119,7 @@ object Cpp {
       case CIf(cond, cons, alt) =>
         "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
       case f:CFor => emitFor(f)
-      case CWhile(cond, body) => "while" <> parens(cond) <+> scope(body)
+      case CWhile(cond, _, body) => "while" <> parens(cond) <+> scope(body)
       case CDecorate(value) => value
       case CUpdate(lhs, rhs) => lhs <+> "=" <+> rhs <> semi
       case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -41,6 +41,7 @@ private class VivadoBackend extends CppLike {
 
   def emitFor(cmd: CFor): Doc =
     "for" <> emitRange(cmd.range) <+> scope {
+      (if (cmd.pipeline) value(s"#pragma HLS PIPELINE\n") else emptyDoc) <>
       unroll(cmd.range.u) <>
       cmd.par <>
       (if (cmd.combine != CEmpty) line <> text("// combiner:") <@> cmd.combine

--- a/src/main/scala/common/Errors.scala
+++ b/src/main/scala/common/Errors.scala
@@ -64,6 +64,10 @@ object Errors {
   case class InsufficientResourcesInUnrollContext(exp: Int, ac: Int, expr: Expr)
     extends TypeError(s"Array access implies $ac safe writes are possible, but surrounding context requires $exp copies.", expr.pos)
 
+  // Pipelining error
+  case class PipelineError(pos: Position) extends TypeError(
+    "Pipelining is only allowed on non-sequenced loops.", pos)
+
   // Subtyping error
   case class NoJoin(pos: Position, cons: String, t1: Type, t2: Type) extends TypeError(
     s"$t1 and $t2 are incomparable. Cannot create a join for construct $cons.", pos)

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -154,7 +154,7 @@ object Syntax {
   case class CView(id: Id, arrId: Id, dims: List[View]) extends Command
   case class CSplit(id: Id, arrId: Id, factors: List[Int]) extends Command
   case class CIf(cond: Expr, cons: Command, alt: Command) extends Command
-  case class CFor(range: CRange, par: Command, combine: Command) extends Command
+  case class CFor(range: CRange, pipeline: Boolean, par: Command, combine: Command) extends Command
   case class CWhile(cond: Expr, body: Command) extends Command
   case class CDecorate(value: String) extends Command
   case class CUpdate(lhs: Expr, rhs: Expr) extends Command {

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -155,7 +155,7 @@ object Syntax {
   case class CSplit(id: Id, arrId: Id, factors: List[Int]) extends Command
   case class CIf(cond: Expr, cons: Command, alt: Command) extends Command
   case class CFor(range: CRange, pipeline: Boolean, par: Command, combine: Command) extends Command
-  case class CWhile(cond: Expr, body: Command) extends Command
+  case class CWhile(cond: Expr, pipeline: Boolean, body: Command) extends Command
   case class CDecorate(value: String) extends Command
   case class CUpdate(lhs: Expr, rhs: Expr) extends Command {
     if (lhs.isLVal == false) throw UnexpectedLVal(lhs, "assignment")

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -90,7 +90,7 @@ object BoundsChecker {
     case _:CSplit => ()
     case CIf(cond, tbranch, fbranch) => checkE(cond) ; checkC(tbranch) ; checkC(fbranch)
     case CFor(_, _, par, combine) => checkC(par) ; checkC(combine)
-    case CWhile(cond, body) => checkE(cond) ; checkC(body)
+    case CWhile(cond, _, body) => checkE(cond) ; checkC(body)
     case _:CDecorate => ()
     case CUpdate(lhs, rhs) => checkE(lhs) ; checkE(rhs)
     case CReduce(_, l, r) => checkE(l) ; checkE(r)

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -89,7 +89,7 @@ object BoundsChecker {
     }
     case _:CSplit => ()
     case CIf(cond, tbranch, fbranch) => checkE(cond) ; checkC(tbranch) ; checkC(fbranch)
-    case CFor(_, par, combine) => checkC(par) ; checkC(combine)
+    case CFor(_, _, par, combine) => checkC(par) ; checkC(combine)
     case CWhile(cond, body) => checkE(cond) ; checkC(body)
     case _:CDecorate => ()
     case CUpdate(lhs, rhs) => checkE(lhs) ; checkE(rhs)

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -73,7 +73,7 @@ object Checker {
         val e2 = nEnv.withScope(checkC(c2)(_))
         e1 merge e2
       }
-      case CFor(_, par, combine) => {
+      case CFor(_, _, par, combine) => {
         val e1 = env.withScope(checkC(par)(_))
         checkC(combine)(e1)
       }

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -77,7 +77,7 @@ object Checker {
         val e1 = env.withScope(checkC(par)(_))
         checkC(combine)(e1)
       }
-      case CWhile(cond, body) => {
+      case CWhile(cond, _, body) => {
         checkE(cond).withScope(checkC(body)(_))
       }
     }

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -112,7 +112,7 @@ object RewriteView {
       c1n <- rewriteC(c1)
       c2n <- rewriteC(c2)
     } yield cf.copy(par = c1n, combine = c2n)
-    case cw@CWhile(_, c) => for {
+    case cw@CWhile(_, _, c) => for {
       cn <- rewriteC(c)
     } yield cw.copy(body = cn)
     case _:CDecorate => State.unit(c)

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -108,7 +108,7 @@ object RewriteView {
       c1n <- rewriteC(c1)
       c2n <- rewriteC(c2)
     } yield CIf(e1n, c1n, c2n)
-    case cf@CFor(_, c1, c2) => for {
+    case cf@CFor(_, _, c1, c2) => for {
       c1n <- rewriteC(c1)
       c2n <- rewriteC(c2)
     } yield cf.copy(par = c1n, combine = c2n)

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -494,7 +494,15 @@ object TypeChecker {
 
       nEnv.add(id, fullTyp)
     }
-    case CFor(range, _, par, combine) => {
+    case CFor(range, pipeline, par, combine) => {
+      // Only loops without sequencing may be pipelined.
+      par match {
+        case _: CSeq => if (pipeline) {
+          throw PipelineError(cmd.pos)
+        }
+        case _ => {}
+      }
+
       val iter = range.iter
       val (e1, binds) = env.withScope(range.u) { newScope =>
         // Add binding for iterator in a separate scope.

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -360,7 +360,7 @@ object TypeChecker {
       val (e3, _) = e1.withScope(1)(e => checkC(alt)(e))
       e2 merge e3
     }
-    case CWhile(cond, body) => {
+    case CWhile(cond, _, body) => {
       val (cTyp, e1) = checkE(cond)(env)
       if (cTyp != TBool()) {
         throw UnexpectedType(cond.pos, "while condition", TBool().toString, cTyp)

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -494,7 +494,7 @@ object TypeChecker {
 
       nEnv.add(id, fullTyp)
     }
-    case CFor(range, par, combine) => {
+    case CFor(range, _, par, combine) => {
       val iter = range.iter
       val (e1, binds) = env.withScope(range.u) { newScope =>
         // Add binding for iterator in a separate scope.

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -350,6 +350,16 @@ object TypeChecker {
     nEnv -> (pre.getOrElse(len) -> newBank)
   }
 
+  private def checkPipeline(enabled: Boolean, loop: Command, body: Command) {
+    // Only loops without sequencing may be pipelined.
+    body match {
+      case _: CSeq => if (enabled) {
+        throw PipelineError(loop.pos)
+      }
+      case _ => {}
+    }
+  }
+
   private def checkC(cmd: Command)
                     (implicit env:Environment): Environment = cmd match {
     case CPar(c1, c2) => checkC(c2)(checkC(c1))
@@ -360,7 +370,8 @@ object TypeChecker {
       val (e3, _) = e1.withScope(1)(e => checkC(alt)(e))
       e2 merge e3
     }
-    case CWhile(cond, _, body) => {
+    case CWhile(cond, pipeline, body) => {
+      checkPipeline(pipeline, cmd, body)
       val (cTyp, e1) = checkE(cond)(env)
       if (cTyp != TBool()) {
         throw UnexpectedType(cond.pos, "while condition", TBool().toString, cTyp)
@@ -495,13 +506,7 @@ object TypeChecker {
       nEnv.add(id, fullTyp)
     }
     case CFor(range, pipeline, par, combine) => {
-      // Only loops without sequencing may be pipelined.
-      par match {
-        case _: CSeq => if (pipeline) {
-          throw PipelineError(cmd.pos)
-        }
-        case _ => {}
-      }
+      checkPipeline(pipeline, cmd, par)
 
       val iter = range.iter
       val (e1, binds) = env.withScope(range.u) { newScope =>

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1027,7 +1027,7 @@ class TypeCheckerSpec extends FunSpec {
   }
 
   describe("Loop pipelining") {
-    it("allowed on simple loop") {
+    it("allowed on simple for loop") {
       typeCheck("""
         for (let i = 0..4) pipeline {
           let a = 1 + 2;
@@ -1036,10 +1036,33 @@ class TypeCheckerSpec extends FunSpec {
         """)
     }
 
-    it("disallowed on sequenced loop") {
+    it("disallowed on sequenced for loop") {
       assertThrows[PipelineError] {
         typeCheck("""
           for (let i = 0..4) pipeline {
+            let a = 1 + 2
+            ---
+            let b = 3 + 4
+          }
+          """)
+      }
+    }
+
+    it("allowed on simple while loop") {
+      typeCheck("""
+        let x = 10;
+        while (x < 100) pipeline {
+          let a = 1 + 2;
+          let b = 3 + 4;
+        }
+        """)
+    }
+
+    it("disallowed on sequenced while loop") {
+      assertThrows[PipelineError] {
+        typeCheck("""
+          let x = 10;
+          while (x < 100) pipeline {
             let a = 1 + 2
             ---
             let b = 3 + 4

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1026,6 +1026,29 @@ class TypeCheckerSpec extends FunSpec {
     }
   }
 
+  describe("Loop pipelining") {
+    it("allowed on simple loop") {
+      typeCheck("""
+        for (let i = 0..4) pipeline {
+          let a = 1 + 2;
+          let b = 3 + 4;
+        }
+        """)
+    }
+
+    it("disallowed on sequenced loop") {
+      assertThrows[PipelineError] {
+        typeCheck("""
+          for (let i = 0..4) pipeline {
+            let a = 1 + 2
+            ---
+            let b = 3 + 4
+          }
+          """)
+      }
+    }
+  }
+
   describe("Records") {
     it("type can be defined") {
       typeCheck("""


### PR DESCRIPTION
This Fuse code:

```
for (let i = 0..4) pipeline {
  let a = 1 + 2;
  let b = 3 + 4;
}
```

works and generated HLS code with a `#pragma HLS PIPELINE` annotation. This version:

```
for (let i = 0..4) pipeline {
  let a = 1 + 2
  ---
  let b = 3 + 4
}
```

fails with a message saying that pipelining is only allowed on non-sequenced loops.