### PR TITLE
executable name can now be customized

### DIFF
--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -50,8 +50,7 @@ CONFIG_OPTIONS = {
 }
 
 # The name to use for compiled executables.
-EXECUTABLE_NAME = 'sdsoc'
-F1_EXECUTABLE_NAME = 'sdaccel'
+EXECUTABLE_NAME = 'exe'
 
 # The number of (recent) lines of the log to show on job pages.
 LOG_PREVIEW_LINES = 32

--- a/buildbot/buildbot/config_default.py
+++ b/buildbot/buildbot/config_default.py
@@ -51,6 +51,7 @@ CONFIG_OPTIONS = {
 
 # The name to use for compiled executables.
 EXECUTABLE_NAME = 'sdsoc'
+F1_EXECUTABLE_NAME = 'sdaccel'
 
 # The number of (recent) lines of the log to show on job pages.
 LOG_PREVIEW_LINES = 32
@@ -59,7 +60,7 @@ LOG_PREVIEW_LINES = 32
 # the synthesis step (or running an opaque Makefile), the latter of
 # which has to be really long because synthesis is so slow.
 COMPILE_TIMEOUT = 120
-SYNTHESIS_TIMEOUT = 9000
+SYNTHESIS_TIMEOUT = 20000
 
 # The Buildbot currently supports two backend toolchains: Xilinx's SDSoC
 # (for Zynq processors) and SDAccel (for AWS F1). Set this to "f1" for

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -487,7 +487,7 @@ def stage_fpga_execute(db, config):
             task.log('skipping FPGA execution stage')
             return
 
-       if config['TOOLCHAIN'] == 'f1':
+        if config['TOOLCHAIN'] == 'f1':
             # On F1, use the run either the real hardware-augmented
             # binary or the emulation executable.
             if task['mode'] == 'hw':

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -493,13 +493,13 @@ def stage_fpga_execute(db, config):
             if task['mode'] == 'hw':
                 exe_cmd = ['sudo', 'sh', '-c',
                            'source /opt/xilinx/xrt/setup.sh ;\
-                            ./{}'.format(config['F1_EXECUTABLE_NAME'])]
+                            ./{}'.format(config['EXECUTABLE_NAME'])]
             else:
                 exe_cmd = ['sh','-c','cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
                 source ./sdaccel_setup.sh > /dev/null; \
                 cd $cur; XCL_EMULATION_MODE={} ./{}'.format(
                     task['mode'], 
-                    config['F1_EXECUTABLE_NAME']
+                    config['EXECUTABLE_NAME']
                     )
                 ]
             task.run(

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -487,20 +487,25 @@ def stage_fpga_execute(db, config):
             task.log('skipping FPGA execution stage')
             return
 
-        if config['TOOLCHAIN'] == 'f1':
+       if config['TOOLCHAIN'] == 'f1':
             # On F1, use the run either the real hardware-augmented
             # binary or the emulation executable.
             if task['mode'] == 'hw':
                 exe_cmd = ['sudo', 'sh', '-c',
-                           'source /opt/xilinx/xrt/setup.sh ; ./host']
+                           'source /opt/xilinx/xrt/setup.sh ;\
+                            ./{}'.format(config['F1_EXECUTABLE_NAME'])]
             else:
-                exe_cmd = ['sh', '-c', 'cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
+                exe_cmd = ['sh','-c','cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
                 source ./sdaccel_setup.sh > /dev/null; \
-                cd $cur; XCL_EMULATION_MODE={} ./host'.format(task['mode'])]
+                cd $cur; XCL_EMULATION_MODE={} ./{}'.format(
+                    task['mode'], 
+                    config['F1_EXECUTABLE_NAME']
+                    )
+                ]
             task.run(
                 exe_cmd,
                 cwd=CODE_DIR,
-                timeout=1800
+                timeout=9000
             )
 
         else:

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -495,7 +495,7 @@ def stage_fpga_execute(db, config):
                            'source /opt/xilinx/xrt/setup.sh ;\
                             ./{}'.format(config['EXECUTABLE_NAME'])]
             else:
-                exe_cmd = ['sh','-c','cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
+                exe_cmd = ['sh', '-c', 'cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
                 source ./sdaccel_setup.sh > /dev/null; \
                 cd $cur; XCL_EMULATION_MODE={} ./{}'.format(
                     task['mode'], 


### PR DESCRIPTION
set a new variable f1-executable-name (currently set to sdaccel) instead of assuming the executable name is host and run ./host.