### PR TITLE
Minor cleanup for F1 bb code

### DIFF
--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -235,15 +235,13 @@ def stage_make(db, config):
             ))
 
         if config['TOOLCHAIN'] == 'f1':
-            # Get the AWS platform ID for F1 builds.
-            platform_script = (
-                'cd $AWS_FPGA_REPO_DIR ; '
-                'source ./sdaccel_setup.sh > /dev/null ; '
-                'echo $AWS_PLATFORM'
+            # Configure current environment.
+            source_script = (
+                'source $AWS_FPGA_REPO_DIR/sdaccel_setup.sh ; '
             )
-            proc = task.run([platform_script], capture=True, shell=True)
-            aws_platform = proc.stdout.decode('utf8').strip()
+            proc = task.run([source_script], capture=True, shell=True)
 
+            aws_platform = os.environ('AWS_PLATFORM')
             make = [
                 'make',
                 'MODE={}'.format(task['mode']),

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -492,9 +492,8 @@ def stage_fpga_execute(db, config):
                 exe_cmd = ['sudo', 'sh', '-c',
                            'source /opt/xilinx/xrt/setup.sh ; ./host']
             else:
-                exe_cmd = ['sh', '-c', 'cur=`pwd`; cd $AWS_FPGA_REPO_DIR ;\
-                source ./sdaccel_setup.sh > /dev/null; \
-                cd $cur; XCL_EMULATION_MODE={} ./host'.format(task['mode'])]
+                exe_cmd = ['sh', '-c', 'source $AWS_FPGA_REPO_DIR/sdaccel_setup.sh > /dev/null;\
+                XCL_EMULATION_MODE={} ./host'.format(task['mode'])]
             task.run(
                 exe_cmd,
                 cwd=CODE_DIR,

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -494,6 +494,7 @@ def stage_fpga_execute(db, config):
             else:
                 exe_cmd = ['sh', '-c', 'source $AWS_FPGA_REPO_DIR/sdaccel_setup.sh > /dev/null;\
                 XCL_EMULATION_MODE={} ./host'.format(task['mode'])]
+
             task.run(
                 exe_cmd,
                 cwd=CODE_DIR,

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -443,14 +443,14 @@ def stage_afi(db, config):
         )
         task.run([afi_script], cwd=CODE_DIR, shell=True)
 
+        # Get the AFI ID.
+        afi_id_files = glob.glob(os.path.join(xcl_dir, '*afi_id.txt'))
+        with open(afi_id_files[0]) as f:
+            afi_id = json.loads(f.read())['FpgaImageId']
+
         # Every 5 minutes, check if the AFI is ready.
         while True:
             time.sleep(config['AFI_CHECK_INTERVAL'])
-
-            # Get the AFI ID.
-            afi_id_files = glob.glob(os.path.join(xcl_dir, '*afi_id.txt'))
-            with open(afi_id_files[0]) as f:
-                afi_id = json.loads(f.read())['FpgaImageId']
 
             # Check the status of the AFI.
             status_string = task.run(

--- a/buildbot/buildbot/worker.py
+++ b/buildbot/buildbot/worker.py
@@ -235,13 +235,15 @@ def stage_make(db, config):
             ))
 
         if config['TOOLCHAIN'] == 'f1':
-            # Configure current environment.
-            source_script = (
-                'source $AWS_FPGA_REPO_DIR/sdaccel_setup.sh ; '
+            # Get the AWS platform ID for F1 builds.
+            platform_script = (
+                'cd $AWS_FPGA_REPO_DIR ; '
+                'source ./sdaccel_setup.sh > /dev/null ; '
+                'echo $AWS_PLATFORM'
             )
-            proc = task.run([source_script], capture=True, shell=True)
+            proc = task.run([platform_script], capture=True, shell=True)
+            aws_platform = proc.stdout.decode('utf8').strip()
 
-            aws_platform = os.environ('AWS_PLATFORM')
             make = [
                 'make',
                 'MODE={}'.format(task['mode']),


### PR DESCRIPTION
Some minor fixes for f1 code.
- `source` can directly refer to the file path. No need to `cd` into a directory unless something weird is going on with F1. 

- `afi` file is generated right after the AFI stage starts (@ViviYe correct?). Just read the value once when polling for the command to finish.