### PR TITLE
Produce program structure mapping to user via `--parent-map` flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "4.0.1",
   "com.outr" %% "scribe" % "3.5.5",
   "com.lihaoyi" %% "sourcecode" % "0.2.7",
-  "com.lihaoyi" %% "upickle" % "4.1.0"
+  "com.lihaoyi" %% "upickle" % "4.1.0",
+  "com.lihaoyi" %% "os-lib" % "0.11.3"
 )
 
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,8 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "fastparse" % "3.0.2",
   "com.github.scopt" %% "scopt" % "4.0.1",
   "com.outr" %% "scribe" % "3.5.5",
-  "com.lihaoyi" %% "sourcecode" % "0.2.7"
+  "com.lihaoyi" %% "sourcecode" % "0.2.7",
+  "com.lihaoyi" %% "upickle" % "4.1.0"
 )
 
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,7 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "fastparse" % "3.0.2",
   "com.github.scopt" %% "scopt" % "4.0.1",
   "com.outr" %% "scribe" % "3.5.5",
-  "com.lihaoyi" %% "sourcecode" % "0.2.7",
-  "com.lihaoyi" %% "upickle" % "4.1.0",
-  "com.lihaoyi" %% "os-lib" % "0.11.3"
+  "com.lihaoyi" %% "sourcecode" % "0.2.7"
 )
 
 scalacOptions ++= Seq(

--- a/file-tests/parent-map/dot-product.expect
+++ b/file-tests/parent-map/dot-product.expect
@@ -1,4 +1,3 @@
-// git.status = clean, build.date = Fri Oct 31 18:06:09 EDT 2025, git.hash = ca4fd12
 import "primitives/core.futil";
 import "primitives/memories/seq.futil";
 import "primitives/binary_operators.futil";

--- a/file-tests/parent-map/dot-product.expect
+++ b/file-tests/parent-map/dot-product.expect
@@ -1,0 +1,116 @@
+// git.status = clean, build.date = Fri Oct 31 18:06:09 EDT 2025, git.hash = ca4fd12
+import "primitives/core.futil";
+import "primitives/memories/seq.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    @pos{0} @external(1) A = seq_mem_d1(32,8,4);
+    @pos{1} A_read0_0 = std_reg(32);
+    @pos{2} @external(1) B = seq_mem_d1(32,8,4);
+    @pos{1} B_read0_0 = std_reg(32);
+    add0 = std_add(32);
+    add1 = std_add(4);
+    @pos{1} bin_read0_0 = std_reg(32);
+    const0 = std_const(4,0);
+    const1 = std_const(1,0);
+    const2 = std_const(1,0);
+    const3 = std_const(4,1);
+    @pos{1} dot_0 = std_reg(32);
+    @pos{3} i0 = std_reg(4);
+    mult_pipe0 = std_mult_pipe(32);
+    @pos{4} red_read00 = std_reg(32);
+    @pos{5} @external(1) v = seq_mem_d1(32,1,1);
+  }
+  wires {
+    group let0<"promotable"=1, "pos"={3}> {
+      i0.in = const0.out;
+      i0.write_en = 1'd1;
+      let0[done] = i0.done;
+    }
+    group let1<"promotable"=2, "pos"={1}> {
+      A_read0_0.in = A.read_data;
+      A_read0_0.write_en = A.done;
+      let1[done] = A_read0_0.done;
+      A.content_en = 1'd1;
+      A.addr0 = i0.out;
+    }
+    group let2<"promotable"=2, "pos"={1}> {
+      B_read0_0.in = B.read_data;
+      B_read0_0.write_en = B.done;
+      let2[done] = B_read0_0.done;
+      B.content_en = 1'd1;
+      B.addr0 = i0.out;
+    }
+    group let3<"promotable"=4, "pos"={1}> {
+      bin_read0_0.in = mult_pipe0.out;
+      bin_read0_0.write_en = mult_pipe0.done;
+      let3[done] = bin_read0_0.done;
+      mult_pipe0.left = A_read0_0.out;
+      mult_pipe0.right = B_read0_0.out;
+      mult_pipe0.go = !mult_pipe0.done ? 1'd1;
+    }
+    group let4<"promotable"=1, "pos"={1}> {
+      dot_0.in = bin_read0_0.out;
+      dot_0.write_en = 1'd1;
+      let4[done] = dot_0.done;
+    }
+    group let5<"promotable"=2, "pos"={4}> {
+      red_read00.in = v.read_data;
+      red_read00.write_en = v.done;
+      let5[done] = red_read00.done;
+      v.content_en = 1'd1;
+      v.addr0 = const1.out;
+    }
+    group upd0<"promotable"=1, "pos"={4}> {
+      v.content_en = 1'd1;
+      v.addr0 = const2.out;
+      v.write_en = 1'd1;
+      add0.left = red_read00.out;
+      add0.right = dot_0.out;
+      v.write_data = add0.out;
+      upd0[done] = v.done;
+    }
+    group upd1<"promotable"=1, "pos"={3}> {
+      i0.write_en = 1'd1;
+      add1.left = i0.out;
+      add1.right = const3.out;
+      i0.in = add1.out;
+      upd1[done] = i0.done;
+    }
+  }
+  control {
+    @pos{3} seq {
+      @pos{3} let0;
+      @pos{3} repeat 8 {
+        @pos{3} seq {
+          @pos{1} par {
+            @pos{1} let1;
+            @pos{1} let2;
+          }
+          @pos{1} let3;
+          @pos{1} let4;
+          @pos{4} let5;
+          @pos{4} upd0;
+          @pos{3} upd1;
+        }
+      }
+    }
+  }
+}
+sourceinfo #{
+  FILES
+  0: file-tests/parent-map/dot-product.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 6
+  2: 0 2
+  3: 0 5
+  4: 0 8
+  5: 0 3
+}#
+---STDERR---
+{
+  "5": [],
+  "6": [5],
+  "8": [5]
+}

--- a/file-tests/parent-map/dot-product.fuse
+++ b/file-tests/parent-map/dot-product.fuse
@@ -1,0 +1,9 @@
+decl A: ubit<32>[8];
+decl B: ubit<32>[8];
+decl v: ubit<32>[1];
+
+for (let i: ubit<4> = 0..8) {
+  let dot = A[i] * B[i];
+} combine {
+  v[0] += dot;
+}

--- a/file-tests/parent-map/nested.expect
+++ b/file-tests/parent-map/nested.expect
@@ -1,0 +1,222 @@
+// git.status = clean, build.date = Fri Oct 31 18:06:09 EDT 2025, git.hash = ca4fd12
+import "primitives/core.futil";
+import "primitives/memories/seq.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    @pos{0} a0_0 = seq_mem_d2(32,8,8,4,4);
+    add0 = std_add(4);
+    add1 = std_add(4);
+    add2 = std_add(4);
+    add3 = std_add(4);
+    @pos{1} b0_0 = seq_mem_d2(32,8,8,4,4);
+    @pos{2} bin_read0_0 = std_reg(4);
+    @pos{3} bin_read1_0 = std_reg(4);
+    const0 = std_const(4,0);
+    const1 = std_const(4,0);
+    const10 = std_const(4,2);
+    const11 = std_const(4,0);
+    const12 = std_const(32,1);
+    const13 = std_const(32,0);
+    const14 = std_const(4,1);
+    const15 = std_const(4,1);
+    const2 = std_const(4,2);
+    const3 = std_const(4,0);
+    const4 = std_const(32,0);
+    const5 = std_const(32,1);
+    const6 = std_const(4,1);
+    const7 = std_const(4,1);
+    const8 = std_const(4,0);
+    const9 = std_const(4,0);
+    @pos{2} div_pipe0 = std_div_pipe(4);
+    @pos{3} div_pipe1 = std_div_pipe(4);
+    eq0 = std_eq(4);
+    eq1 = std_eq(4);
+    @pos{4} i0 = std_reg(4);
+    @pos{5} i1 = std_reg(4);
+    @pos{6} j0 = std_reg(4);
+    @pos{7} j1 = std_reg(4);
+  }
+  wires {
+    comb group cond0<"pos"={2}> {
+      eq0.left = bin_read0_0.out;
+      eq0.right = const3.out;
+    }
+    comb group cond1<"pos"={3}> {
+      eq1.left = bin_read1_0.out;
+      eq1.right = const11.out;
+    }
+    group let0<"promotable"=1, "pos"={4}> {
+      i0.in = const0.out;
+      i0.write_en = 1'd1;
+      let0[done] = i0.done;
+    }
+    group let1<"promotable"=1, "pos"={6}> {
+      j0.in = const1.out;
+      j0.write_en = 1'd1;
+      let1[done] = j0.done;
+    }
+    group let2<"pos"={2}> {
+      bin_read0_0.in = div_pipe0.out_remainder;
+      bin_read0_0.write_en = div_pipe0.done;
+      let2[done] = bin_read0_0.done;
+      div_pipe0.left = i0.out;
+      div_pipe0.right = const2.out;
+      div_pipe0.go = !div_pipe0.done ? 1'd1;
+    }
+    group let3<"promotable"=1, "pos"={5}> {
+      i1.in = const8.out;
+      i1.write_en = 1'd1;
+      let3[done] = i1.done;
+    }
+    group let4<"promotable"=1, "pos"={7}> {
+      j1.in = const9.out;
+      j1.write_en = 1'd1;
+      let4[done] = j1.done;
+    }
+    group let5<"pos"={3}> {
+      bin_read1_0.in = div_pipe1.out_remainder;
+      bin_read1_0.write_en = div_pipe1.done;
+      let5[done] = bin_read1_0.done;
+      div_pipe1.left = i1.out;
+      div_pipe1.right = const10.out;
+      div_pipe1.go = !div_pipe1.done ? 1'd1;
+    }
+    group upd0<"promotable"=1, "pos"={8}> {
+      a0_0.content_en = 1'd1;
+      a0_0.addr1 = j0.out;
+      a0_0.addr0 = i0.out;
+      a0_0.write_en = 1'd1;
+      a0_0.write_data = const4.out;
+      upd0[done] = a0_0.done;
+    }
+    group upd1<"promotable"=1, "pos"={9}> {
+      a0_0.content_en = 1'd1;
+      a0_0.addr1 = j0.out;
+      a0_0.addr0 = i0.out;
+      a0_0.write_en = 1'd1;
+      a0_0.write_data = const5.out;
+      upd1[done] = a0_0.done;
+    }
+    group upd2<"promotable"=1, "pos"={6}> {
+      j0.write_en = 1'd1;
+      add0.left = j0.out;
+      add0.right = const6.out;
+      j0.in = add0.out;
+      upd2[done] = j0.done;
+    }
+    group upd3<"promotable"=1, "pos"={4}> {
+      i0.write_en = 1'd1;
+      add1.left = i0.out;
+      add1.right = const7.out;
+      i0.in = add1.out;
+      upd3[done] = i0.done;
+    }
+    group upd4<"promotable"=1, "pos"={10}> {
+      b0_0.content_en = 1'd1;
+      b0_0.addr1 = j1.out;
+      b0_0.addr0 = i1.out;
+      b0_0.write_en = 1'd1;
+      b0_0.write_data = const12.out;
+      upd4[done] = b0_0.done;
+    }
+    group upd5<"promotable"=1, "pos"={11}> {
+      b0_0.content_en = 1'd1;
+      b0_0.addr1 = j1.out;
+      b0_0.addr0 = i1.out;
+      b0_0.write_en = 1'd1;
+      b0_0.write_data = const13.out;
+      upd5[done] = b0_0.done;
+    }
+    group upd6<"promotable"=1, "pos"={7}> {
+      j1.write_en = 1'd1;
+      add2.left = j1.out;
+      add2.right = const14.out;
+      j1.in = add2.out;
+      upd6[done] = j1.done;
+    }
+    group upd7<"promotable"=1, "pos"={5}> {
+      i1.write_en = 1'd1;
+      add3.left = i1.out;
+      add3.right = const15.out;
+      i1.in = add3.out;
+      upd7[done] = i1.done;
+    }
+  }
+  control {
+    @pos{5} par {
+      @pos{4} seq {
+        @pos{4} let0;
+        @pos{4} repeat 8 {
+          @pos{4} seq {
+            @pos{6} let1;
+            @pos{6} repeat 8 {
+              @pos{6} seq {
+                @pos{2} let2;
+                @pos{2} if eq0.out with cond0 {
+                  @pos{8} upd0;
+                } else {
+                  @pos{9} upd1;
+                }
+                @pos{6} upd2;
+              }
+            }
+            @pos{4} upd3;
+          }
+        }
+      }
+      @pos{5} seq {
+        @pos{5} let3;
+        @pos{5} repeat 8 {
+          @pos{5} seq {
+            @pos{7} let4;
+            @pos{7} repeat 8 {
+              @pos{7} seq {
+                @pos{3} let5;
+                @pos{3} if eq1.out with cond1 {
+                  @pos{10} upd4;
+                } else {
+                  @pos{11} upd5;
+                }
+                @pos{7} upd6;
+              }
+            }
+            @pos{5} upd7;
+          }
+        }
+      }
+    }
+  }
+}
+sourceinfo #{
+  FILES
+  0: file-tests/parent-map/nested.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 2
+  2: 0 6
+  3: 0 16
+  4: 0 4
+  5: 0 14
+  6: 0 5
+  7: 0 15
+  8: 0 7
+  9: 0 9
+  10: 0 17
+  11: 0 19
+}#
+---STDERR---
+{
+  "5": [4],
+  "14": [],
+  "1": [],
+  "6": [5,4],
+  "9": [6,5,4],
+  "2": [],
+  "17": [16,15,14],
+  "7": [6,5,4],
+  "16": [15,14],
+  "19": [16,15,14],
+  "4": [],
+  "15": [14]
+}

--- a/file-tests/parent-map/nested.expect
+++ b/file-tests/parent-map/nested.expect
@@ -1,4 +1,3 @@
-// git.status = clean, build.date = Fri Oct 31 18:06:09 EDT 2025, git.hash = ca4fd12
 import "primitives/core.futil";
 import "primitives/memories/seq.futil";
 import "primitives/binary_operators.futil";
@@ -207,16 +206,16 @@ sourceinfo #{
 }#
 ---STDERR---
 {
-  "5": [4],
-  "14": [],
   "1": [],
-  "6": [5,4],
-  "9": [6,5,4],
   "2": [],
-  "17": [16,15,14],
-  "7": [6,5,4],
-  "16": [15,14],
-  "19": [16,15,14],
   "4": [],
-  "15": [14]
+  "5": [4],
+  "6": [5,4],
+  "7": [6,5,4],
+  "9": [6,5,4],
+  "14": [],
+  "15": [14],
+  "16": [15,14],
+  "17": [16,15,14],
+  "19": [16,15,14]
 }

--- a/file-tests/parent-map/nested.fuse
+++ b/file-tests/parent-map/nested.fuse
@@ -1,0 +1,22 @@
+let a: ubit<32>[8][8];
+let b: ubit<32>[8][8];
+
+for (let i: ubit<4> = 0..8) {
+  for (let j: ubit<4> = 0..8) {
+    if (i % 2 == 0) {
+       a[i][j] := 0;
+    } else {
+       a[i][j] := 1;
+    }
+  }
+}
+
+for (let i: ubit<4> = 0..8) {
+  for (let j: ubit<4> = 0..8) {
+    if (i % 2 == 0) {
+       b[i][j] := 1;
+    } else {
+       b[i][j] := 0;
+    }
+  }
+}

--- a/runt.toml
+++ b/runt.toml
@@ -31,7 +31,7 @@ cmd = "./fuse {}"
 name = "parent map"
 paths = [ "file-tests/parent-map/*.fuse" ]
 cmd = """
-./fuse {} --lower -b futil -l error --parent-map {}.tmp_err_file ; cat {}.tmp_err_file 1>&2; rm {}.tmp_err_file
+./fuse {} --lower -b futil -l error --parent-map {}.tmp_err_file | tail -n+2 ; cat {}.tmp_err_file 1>&2; rm {}.tmp_err_file
 """
 
 [[tests]]

--- a/runt.toml
+++ b/runt.toml
@@ -28,6 +28,13 @@ paths = [ "file-tests/should-fail/*.fuse" ]
 cmd = "./fuse {}"
 
 [[tests]]
+name = "parent map"
+paths = [ "file-tests/parent-map/*.fuse" ]
+cmd = """
+./fuse {} --lower -b futil -l error --parent-map {}.tmp_err_file ; cat {}.tmp_err_file 1>&2; rm {}.tmp_err_file
+"""
+
+[[tests]]
 name = "run"
 paths = [ "file-tests/should-run/*.fuse" ]
 cmd = """

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -74,8 +74,9 @@ object Compiler:
         val tAdded = computeAncestors(t, currSymbolOpt, currAdded)
         computeAncestors(f, currSymbolOpt, tAdded)
       }
-      case CEmpty => {
-        // don't care about empty commands for now, so we'll return the original map unmodified
+      case CEmpty | CView(_,_,_) | CDecorate(_) => {
+        // commands that we don't need to record 
+        // return the original map unmodified
         linumToAncestors}
       case _ => {currAdded}
     }
@@ -85,13 +86,13 @@ object Compiler:
     val cmd = prog.cmd
     val linumToParentsMap = computeAncestors(cmd, None, Map())
 
-    // write map to file
+    // write map to json file
     val writer = new PrintWriter(new File(pathString))
     writer.println("{")
-    for ((k, v) <- linumToParentsMap) {
-      writer.println(s"  ${k}: [${v.mkString(",")}],")
-    }
-    writer.println("}")
+    var count = 0
+    val outStrList = linumToParentsMap.map((k, v) => s"  \"${k}\": [${v.mkString(",")}]");
+    writer.print(outStrList.mkString(",\n"))
+    writer.println("\n}")
     writer.close()
   }
 

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -1,16 +1,14 @@
 package fuselang
 
-import scala.util.parsing.input.Position
 import scala.util.Try
-import scala.collection.SortedMap
 import scala.io.Source
-import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import common.*
 import Configuration.*
 import Syntax.*
 import Transformer.{PartialTransformer, TypedPartialTransformer}
 
 import java.io.{File, PrintWriter}
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 
 object Compiler:
 

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -86,13 +86,14 @@ object Compiler:
     val cmd = prog.cmd
     val linumToParentsMap = computeAncestors(cmd, None, Map())
 
-    // write map to json file
+    // create JSON string
+    val parentMapStr = new StringBuilder("{\n")
+    val outStrList = linumToParentsMap.map((k, v) => s"  \"${k}\": [${v.mkString(",")}]")
+    parentMapStr ++= outStrList.mkString(",\n")
+    parentMapStr ++= "\n}"
+
     val writer = new PrintWriter(new File(pathString))
-    writer.println("{")
-    var count = 0
-    val outStrList = linumToParentsMap.map((k, v) => s"  \"${k}\": [${v.mkString(",")}]");
-    writer.print(outStrList.mkString(",\n"))
-    writer.println("\n}")
+    writer.println(parentMapStr)
     writer.close()
   }
 

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -2,6 +2,7 @@ package fuselang
 
 import scala.util.parsing.input.Position
 import scala.util.Try
+import scala.collection.SortedMap
 import scala.io.Source
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import common.*
@@ -84,15 +85,15 @@ object Compiler:
 
   def writeParentMap(prog: Prog, pathString: String): Unit = {
     val cmd = prog.cmd
-    val linumToParentsMap = computeAncestors(cmd, None, Map())
+    val linumToParentsMap = computeAncestors(cmd, None, Map()).to(collection.immutable.SortedMap)
 
     // create JSON string
-    val parentMapStr = new StringBuilder("{\n")
+    val parentMapStr = StringBuilder("{\n")
     val outStrList = linumToParentsMap.map((k, v) => s"  \"${k}\": [${v.mkString(",")}]")
     parentMapStr ++= outStrList.mkString(",\n")
     parentMapStr ++= "\n}"
 
-    val writer = new PrintWriter(new File(pathString))
+    val writer = PrintWriter(File(pathString))
     writer.println(parentMapStr)
     writer.close()
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -47,11 +47,6 @@ object Main:
       .action((f, c) => c.copy(output = Some(f)))
       .text("Output code in a file. Default: use stdout.")
 
-    opt[String]("path-descriptor")
-      .valueName("<jsonFile>")
-      .action((f, c) => c.copy(pathDescriptorPath = Some(f)))
-      .text("file to write path descriptor mapping JSON to. (MUST be absolute path)")
-
     opt[String]('n', "name")
       .valueName("<kernel>")
       .validate(x =>
@@ -88,6 +83,11 @@ object Main:
     opt[Unit]("pass-debug")
       .action((_, c) => c.copy(passDebug = true))
       .text("Show the AST after every compiler pass. Default: false.")
+
+    opt[String]("parent-map")
+      .valueName("<jsonFile>")
+      .action((f, c) => c.copy(parentMapPath = Some(f)))
+      .text("File to write parent line mapping JSON to. The map indicates which while/for/if blocks a statement may be nested in.")
 
     opt[String]("memory-interface")
       .validate(b =>

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -47,6 +47,11 @@ object Main:
       .action((f, c) => c.copy(output = Some(f)))
       .text("Output code in a file. Default: use stdout.")
 
+    opt[String]("path-descriptor")
+      .valueName("<jsonFile>")
+      .action((f, c) => c.copy(pathDescriptorPath = Some(f)))
+      .text("file to write path descriptor mapping JSON to. (MUST be absolute path)")
+
     opt[String]('n', "name")
       .valueName("<kernel>")
       .validate(x =>
@@ -120,7 +125,6 @@ object Main:
     val prog = Files.exists(path) match
       case true => Right(new String(Files.readAllBytes(path)))
       case false => Left(s"$path: No such file in working directory")
-
     
     val cppPath: Either[ErrString, Option[Path]] = prog.flatMap(prog =>
       conf.output match {

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -121,6 +121,7 @@ object Main:
       case true => Right(new String(Files.readAllBytes(path)))
       case false => Left(s"$path: No such file in working directory")
 
+    
     val cppPath: Either[ErrString, Option[Path]] = prog.flatMap(prog =>
       conf.output match {
         case Some(out) =>

--- a/src/main/scala/common/Configuration.scala
+++ b/src/main/scala/common/Configuration.scala
@@ -43,5 +43,6 @@ object Configuration:
       logLevel: scribe.Level = scribe.Level.Warn,
       enableLowering: Boolean = false, // Enable lowering passes
       memoryInterface: MemoryInterface = Axi, // The memory interface to use for vivado
+      pathDescriptorPath: Option[String] = None, // Path to write path descriptor mapping to
   )
 

--- a/src/main/scala/common/Configuration.scala
+++ b/src/main/scala/common/Configuration.scala
@@ -32,17 +32,17 @@ object Configuration:
   val emptyConf = Config(null)
 
   case class Config(
-      srcFile: File, // Required: Name of the source file
-      kernelName: String = "kernel", // Name of the kernel to emit
-      output: Option[String] = None, // Name of output file.
-      backend: BackendOption = Vivado, // Backend used for code generation
-      mode: Mode = Compile, // Compilation mode
-      compilerOpts: List[String] = List(), // Extra options for the backend
-      header: Boolean = false, // Generate a header
-      passDebug: Boolean = false, // Show AST after every state
-      logLevel: scribe.Level = scribe.Level.Warn,
-      enableLowering: Boolean = false, // Enable lowering passes
-      memoryInterface: MemoryInterface = Axi, // The memory interface to use for vivado
-      pathDescriptorPath: Option[String] = None, // Path to write path descriptor mapping to
+                     srcFile: File, // Required: Name of the source file
+                     kernelName: String = "kernel", // Name of the kernel to emit
+                     output: Option[String] = None, // Name of output file.
+                     backend: BackendOption = Vivado, // Backend used for code generation
+                     mode: Mode = Compile, // Compilation mode
+                     compilerOpts: List[String] = List(), // Extra options for the backend
+                     header: Boolean = false, // Generate a header
+                     passDebug: Boolean = false, // Show AST after every state
+                     logLevel: scribe.Level = scribe.Level.Warn,
+                     enableLowering: Boolean = false, // Enable lowering passes
+                     memoryInterface: MemoryInterface = Axi, // The memory interface to use for vivado
+                     parentMapPath: Option[String] = None, // Path to write path descriptor mapping to
   )
 

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -9,14 +9,20 @@ import Configuration.BackendOption
 object Syntax:
 
   trait PositionalWithSpan extends Positional:
-    var span: Int = 0
+    var span: Int = 0 // horizontal span (columns)
+    var vspan: Int = 0 // vertical span (lines)
 
     def setSpan(span: Int): this.type =
       this.span = span
       this
+      
+    def setVspan(vspan: Int): this.type = {
+      this.vspan = vspan
+      this
+    }
 
     def withPos[T <: PositionalWithSpan](other: T): this.type =
-      this.setPos(other.pos).setSpan(other.span)
+      this.setPos(other.pos).setSpan(other.span).setVspan(other.vspan)
       this
 
   /**


### PR DESCRIPTION
This PR adds the `--parent-map` flag, which produces a JSON file that maps from commands' line numbers (converted into strings) to a list of line numbers of "ancestor" commands in which the key command is nested within. Currently, "ancestor" commands are only `while`, `for`, and `if`, but other commands can be added in the future.

Example: [`nested.fuse`](https://github.com/cucapra/dahlia/blob/master/file-tests/should-lower/nested.fuse) contains nested for-loops, where line 6 is the outer loop and line 7 is the inner loop. Additionally, there is an `if` statement on line 10 that has a `then` block at line 11. Using `--parent-map`, we get the following output:
```
{
  "10": [7,6],
  "14": [7,6],
  "1": [],
  "6": [],
  "2": [],
  "7": [6],
  "3": [],
  "11": [10,7,6],
  "8": [7,6],  
  "4": []
}
```

This is primarily for use in profiling Dahlia programs and showing the relationships between statements in the output, but may be useful in other ways?